### PR TITLE
Add Zenless Zone Zero support to EnkaDotNet

### DIFF
--- a/EnkaDotNet/Assets/AssetsFactory.cs
+++ b/EnkaDotNet/Assets/AssetsFactory.cs
@@ -1,4 +1,5 @@
 ﻿using EnkaDotNet.Assets.Genshin;
+using EnkaDotNet.Assets.ZZZ;
 using EnkaDotNet.Enums;
 using EnkaDotNet.Exceptions;
 
@@ -11,6 +12,7 @@ namespace EnkaDotNet.Assets
             return gameType switch
             {
                 GameType.Genshin => new GenshinAssets(language),
+                GameType.ZZZ => new ZZZAssets(language),
                 _ => throw new UnsupportedGameTypeException(gameType, $"Game type {gameType} is not supported.")
             };
         }
@@ -18,6 +20,11 @@ namespace EnkaDotNet.Assets
         public static IGenshinAssets CreateGenshin(string language = "en")
         {
             return new GenshinAssets(language);
+        }
+
+        public static IZZZAssets CreateZZZ(string language = "en")
+        {
+            return new ZZZAssets(language);
         }
     }
 }

--- a/EnkaDotNet/Assets/ZZZ/IZZZAssets.cs
+++ b/EnkaDotNet/Assets/ZZZ/IZZZAssets.cs
@@ -1,0 +1,45 @@
+﻿using EnkaDotNet.Assets.ZZZ.Models;
+using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Assets.ZZZ
+{
+    public interface IZZZAssets : IAssets
+    {
+        string GetLocalizedText(string key);
+
+        string GetAgentName(int agentId);
+        string GetAgentIconUrl(int agentId);
+        string GetAgentCircleIconUrl(int agentId);
+        List<ElementType> GetAgentElements(int agentId);
+        ProfessionType GetAgentProfessionType(int agentId);
+        int GetAgentRarity(int agentId);
+
+        ZZZAvatarAssetInfo? GetAvatarInfo(string agentId);
+
+        string GetWeaponName(int weaponId);
+        string GetWeaponIconUrl(int weaponId);
+        ProfessionType GetWeaponType(int weaponId);
+        int GetWeaponRarity(int weaponId);
+
+        ZZZWeaponAssetInfo? GetWeaponInfo(string weaponId);
+
+        string GetDriveDiscSuitName(int suitId);
+        string GetDriveDiscSuitIconUrl(int suitId);
+        int GetDriveDiscRarity(int discId);
+        int GetDriveDiscSuitId(int discId);
+
+        string GetPropertyName(int propertyId);
+        string FormatPropertyValue(int propertyId, double value);
+
+        string GetTitleText(int titleId);
+        string GetMedalName(int medalId);
+        string GetMedalIconUrl(int medalId);
+
+        string GetNameCardIconUrl(int nameCardId);
+        string GetProfilePictureIconUrl(int profilePictureId);
+        string GetSkillIconUrl(int agentId, SkillType skillType);
+
+        ZZZEquipmentSuitInfo? GetDiscSetInfo(string suitId);
+        Dictionary<string, ZZZEquipmentSuitInfo> GetAllDiscSets();
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZAvatarAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZAvatarAssetInfo.cs
@@ -1,0 +1,55 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZAvatarAssetInfo
+    {
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("Rarity")]
+        public int Rarity { get; set; }
+
+        [JsonPropertyName("ProfessionType")]
+        public string? ProfessionType { get; set; }
+
+        [JsonPropertyName("ElementTypes")]
+        public List<string>? ElementTypes { get; set; }
+
+        [JsonPropertyName("Image")]
+        public string? Image { get; set; }
+
+        [JsonPropertyName("CircleIcon")]
+        public string? CircleIcon { get; set; }
+
+        [JsonPropertyName("WeaponId")]
+        public int WeaponId { get; set; }
+
+        [JsonPropertyName("Colors")]
+        public ZZZAvatarColors? Colors { get; set; }
+
+        [JsonPropertyName("HighlightProps")]
+        public List<int>? HighlightProps { get; set; }
+
+        [JsonPropertyName("BaseProps")]
+        public Dictionary<string, int>? BaseProps { get; set; }
+
+        [JsonPropertyName("GrowthProps")]
+        public Dictionary<string, int>? GrowthProps { get; set; }
+
+        [JsonPropertyName("PromotionProps")]
+        public List<Dictionary<string, int>>? PromotionProps { get; set; }
+
+        [JsonPropertyName("CoreEnhancementProps")]
+        public List<Dictionary<string, int>>? CoreEnhancementProps { get; set; }
+    }
+
+    public class ZZZAvatarColors
+    {
+        [JsonPropertyName("Accent")]
+        public string? Accent { get; set; }
+
+        [JsonPropertyName("Mindscape")]
+        public string? Mindscape { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZEquipmentAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZEquipmentAssetInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZEquipmentData
+    {
+        [JsonPropertyName("Items")]
+        public Dictionary<string, ZZZEquipmentItemInfo>? Items { get; set; }
+
+        [JsonPropertyName("Suits")]
+        public Dictionary<string, ZZZEquipmentSuitInfo>? Suits { get; set; }
+    }
+
+    public class ZZZEquipmentItemInfo
+    {
+        [JsonPropertyName("Rarity")]
+        public int Rarity { get; set; }
+
+        [JsonPropertyName("SuitId")]
+        public int SuitId { get; set; }
+    }
+
+    public class ZZZEquipmentSuitInfo
+    {
+        [JsonPropertyName("Icon")]
+        public string? Icon { get; set; }
+
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("SetBonusProps")]
+        public Dictionary<string, int>? SetBonusProps { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZMedalAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZMedalAssetInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZMedalAssetInfo
+    {
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("Icon")]
+        public string? Icon { get; set; }
+
+        [JsonPropertyName("TipNum")]
+        public string? TipNum { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZNameCardAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZNameCardAssetInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZNameCardAssetInfo
+    {
+        [JsonPropertyName("Icon")]
+        public string? Icon { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZPfpAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZPfpAssetInfo.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZPfpAssetInfo
+    {
+        [JsonPropertyName("Icon")]
+        public string? Icon { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZPropertyAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZPropertyAssetInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZPropertyAssetInfo
+    {
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("Format")]
+        public string? Format { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZTitleAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZTitleAssetInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZTitleAssetInfo
+    {
+        [JsonPropertyName("TitleText")]
+        public string? TitleText { get; set; }
+
+        [JsonPropertyName("ColorA")]
+        public string? ColorA { get; set; }
+
+        [JsonPropertyName("ColorB")]
+        public string? ColorB { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/Models/ZZZWeaponAssetInfo.cs
+++ b/EnkaDotNet/Assets/ZZZ/Models/ZZZWeaponAssetInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Assets.ZZZ.Models
+{
+    public class ZZZWeaponAssetInfo
+    {
+        [JsonPropertyName("ItemName")]
+        public string? ItemName { get; set; }
+
+        [JsonPropertyName("Rarity")]
+        public int Rarity { get; set; }
+
+        [JsonPropertyName("ProfessionType")]
+        public string? ProfessionType { get; set; }
+
+        [JsonPropertyName("ImagePath")]
+        public string? ImagePath { get; set; }
+
+        [JsonPropertyName("MainStat")]
+        public ZZZStatProperty? MainStat { get; set; }
+
+        [JsonPropertyName("SecondaryStat")]
+        public ZZZStatProperty? SecondaryStat { get; set; }
+    }
+
+    public class ZZZStatProperty
+    {
+        [JsonPropertyName("PropertyId")]
+        public int PropertyId { get; set; }
+
+        [JsonPropertyName("PropertyValue")]
+        public int PropertyValue { get; set; }
+    }
+}

--- a/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
+++ b/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
@@ -1,0 +1,567 @@
+﻿using System.Text.Json;
+using EnkaDotNet.Assets.ZZZ.Models;
+using EnkaDotNet.Enums;
+using EnkaDotNet.Enums.ZZZ;
+using EnkaDotNet.Utils;
+
+namespace EnkaDotNet.Assets.ZZZ
+{
+    public class ZZZAssets : BaseAssets, IZZZAssets
+    {
+        private static readonly Dictionary<string, string> ZZZAssetUrls = new()
+        {
+            { "text_map.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/locs.json" },
+            { "avatars.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/avatars.json" },
+            { "weapons.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/weapons.json" },
+            { "equipments.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/equipments.json" },
+            { "pfps.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/pfps.json" },
+            { "namecards.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/namecards.json" },
+            { "medals.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/medals.json" },
+            { "titles.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/titles.json" },
+            { "property.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/zzz/property.json" }
+        };
+
+        private readonly Dictionary<string, ZZZAvatarAssetInfo> _avatars = new();
+        private readonly Dictionary<string, ZZZWeaponAssetInfo> _weapons = new();
+        private readonly Dictionary<string, ZZZPfpAssetInfo> _pfps = new();
+        private readonly Dictionary<string, ZZZNameCardAssetInfo> _namecards = new();
+        private readonly Dictionary<string, ZZZTitleAssetInfo> _titles = new();
+        private readonly Dictionary<string, ZZZMedalAssetInfo> _medals = new();
+        private readonly Dictionary<string, ZZZPropertyAssetInfo> _properties = new();
+        private readonly Dictionary<string, ZZZEquipmentItemInfo> _equipmentItems = new();
+        private readonly Dictionary<string, ZZZEquipmentSuitInfo> _equipmentSuits = new();
+        private Dictionary<string, string>? _localization;
+
+        public ZZZAssets(string language = "en")
+            : base(language, GameType.ZZZ)
+        {
+        }
+
+        protected override Dictionary<string, string> GetAssetUrls() => ZZZAssetUrls;
+
+        protected override async Task LoadAssets()
+        {
+            var tasks = new List<Task>
+            {
+                LoadLocalizations(),
+                LoadAvatars(),
+                LoadWeapons(),
+                LoadEquipments(),
+                LoadPfps(),
+                LoadNamecards(),
+                LoadMedals(),
+                LoadTitles(),
+                LoadProperties()
+            };
+
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task LoadLocalizations()
+        {
+            try
+            {
+                var localizationData = await FetchAndDeserializeAssetAsync<Dictionary<string, Dictionary<string, string>>>("text_map.json");
+                if (localizationData.TryGetValue(Language, out var langMap))
+                {
+                    _localization = langMap;
+                }
+                else if (localizationData.TryGetValue("en", out var enMap))
+                {
+                    _localization = enMap;
+                    Console.WriteLine($"[Assets] Language '{Language}' not found, falling back to English");
+                }
+                else
+                {
+                    _localization = localizationData.FirstOrDefault().Value;
+                    Console.WriteLine($"[Assets] English language not found, using first available language");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading localizations: {ex.Message}");
+                _localization = new Dictionary<string, string>();
+            }
+        }
+
+        private async Task LoadAvatars()
+        {
+            _avatars.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZAvatarAssetInfo>>("avatars.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _avatars[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading avatars: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential avatars data", ex);
+            }
+        }
+
+        private async Task LoadWeapons()
+        {
+            _weapons.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZWeaponAssetInfo>>("weapons.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _weapons[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading weapons: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential weapons data", ex);
+            }
+        }
+
+        private async Task LoadEquipments()
+        {
+            _equipmentItems.Clear();
+            _equipmentSuits.Clear();
+            try
+            {
+                var deserializedData = await FetchAndDeserializeAssetAsync<ZZZEquipmentData>("equipments.json");
+
+                if (deserializedData.Items != null)
+                {
+                    foreach (var kvp in deserializedData.Items)
+                    {
+                        _equipmentItems[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                if (deserializedData.Suits != null)
+                {
+                    foreach (var kvp in deserializedData.Suits)
+                    {
+                        _equipmentSuits[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading equipments: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential equipments data", ex);
+            }
+        }
+
+        private async Task LoadPfps()
+        {
+            _pfps.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZPfpAssetInfo>>("pfps.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _pfps[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading profile pictures: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential profile pictures data", ex);
+            }
+        }
+
+        private async Task LoadNamecards()
+        {
+            _namecards.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZNameCardAssetInfo>>("namecards.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _namecards[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading namecards: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential namecards data", ex);
+            }
+        }
+
+        private async Task LoadMedals()
+        {
+            _medals.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZMedalAssetInfo>>("medals.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _medals[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading medals: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential medals data", ex);
+            }
+        }
+
+        private async Task LoadTitles()
+        {
+            _titles.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZTitleAssetInfo>>("titles.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _titles[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading titles: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential titles data", ex);
+            }
+        }
+
+        private async Task LoadProperties()
+        {
+            _properties.Clear();
+            try
+            {
+                var deserializedMap = await FetchAndDeserializeAssetAsync<Dictionary<string, ZZZPropertyAssetInfo>>("property.json");
+                foreach (var kvp in deserializedMap)
+                {
+                    _properties[kvp.Key] = kvp.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Assets] Error loading properties: {ex.Message}");
+                throw new InvalidOperationException($"Failed to load essential properties data", ex);
+            }
+        }
+
+        public string GetLocalizedText(string key)
+        {
+            if (_localization != null && !string.IsNullOrEmpty(key) && _localization.TryGetValue(key, out var text))
+            {
+                return text;
+            }
+            return key;
+        }
+
+        public ZZZAvatarAssetInfo? GetAvatarInfo(string agentId)
+        {
+            if (_avatars.TryGetValue(agentId, out var avatarInfo))
+            {
+                return avatarInfo;
+            }
+            return null;
+        }
+
+        public ZZZWeaponAssetInfo? GetWeaponInfo(string weaponId)
+        {
+            if (_weapons.TryGetValue(weaponId, out var weaponInfo))
+            {
+                return weaponInfo;
+            }
+            return null;
+        }
+
+        public string GetAgentName(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo))
+            {
+                if (!string.IsNullOrEmpty(avatarInfo.Name))
+                {
+                    string localizedName = GetLocalizedText(avatarInfo.Name);
+                    if (localizedName != avatarInfo.Name)
+                    {
+                        return localizedName;
+                    }
+
+                    if (avatarInfo.Name.Contains("_"))
+                    {
+                        string[] nameParts = avatarInfo.Name.Split('_');
+                        if (nameParts.Length > 0)
+                        {
+                            return nameParts[nameParts.Length - 1];
+                        }
+                    }
+
+                    return avatarInfo.Name;
+                }
+            }
+            return $"Agent_{agentId}";
+        }
+
+        public string GetAgentIconUrl(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo) && !string.IsNullOrEmpty(avatarInfo.Image))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{avatarInfo.Image}";
+            }
+            return string.Empty;
+        }
+
+        public string GetAgentCircleIconUrl(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo) && !string.IsNullOrEmpty(avatarInfo.CircleIcon))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{avatarInfo.CircleIcon}";
+            }
+            return string.Empty;
+        }
+
+        public List<ElementType> GetAgentElements(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            var elements = new List<ElementType>();
+
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo) && avatarInfo.ElementTypes != null)
+            {
+                foreach (var element in avatarInfo.ElementTypes)
+                {
+                    elements.Add(MapElementNameToEnum(element));
+                }
+            }
+
+            return elements;
+        }
+
+        public ProfessionType GetAgentProfessionType(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo) && !string.IsNullOrEmpty(avatarInfo.ProfessionType))
+            {
+                return MapProfessionNameToEnum(avatarInfo.ProfessionType);
+            }
+            return ProfessionType.Unknown;
+        }
+
+        public int GetAgentRarity(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo))
+            {
+                return avatarInfo.Rarity;
+            }
+            return 0;
+        }
+
+        public ZZZEquipmentSuitInfo? GetDiscSetInfo(string suitId)
+        {
+            if (_equipmentSuits.TryGetValue(suitId, out var suitInfo))
+            {
+                return suitInfo;
+            }
+            return null;
+        }
+
+        public Dictionary<string, ZZZEquipmentSuitInfo> GetAllDiscSets()
+        {
+            return _equipmentSuits;
+        }
+
+        public string GetWeaponName(int weaponId)
+        {
+            string weaponIdStr = weaponId.ToString();
+            if (_weapons.TryGetValue(weaponIdStr, out var weaponInfo) && !string.IsNullOrEmpty(weaponInfo.ItemName))
+            {
+                return GetLocalizedText(weaponInfo.ItemName);
+            }
+            return $"Weapon_{weaponId}";
+        }
+
+        public string GetWeaponIconUrl(int weaponId)
+        {
+            string weaponIdStr = weaponId.ToString();
+            if (_weapons.TryGetValue(weaponIdStr, out var weaponInfo) && !string.IsNullOrEmpty(weaponInfo.ImagePath))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{weaponInfo.ImagePath}";
+            }
+            return string.Empty;
+        }
+
+        public ProfessionType GetWeaponType(int weaponId)
+        {
+            string weaponIdStr = weaponId.ToString();
+            if (_weapons.TryGetValue(weaponIdStr, out var weaponInfo) && !string.IsNullOrEmpty(weaponInfo.ProfessionType))
+            {
+                return MapProfessionNameToEnum(weaponInfo.ProfessionType);
+            }
+            return ProfessionType.Unknown;
+        }
+
+        public int GetWeaponRarity(int weaponId)
+        {
+            string weaponIdStr = weaponId.ToString();
+            if (_weapons.TryGetValue(weaponIdStr, out var weaponInfo))
+            {
+                return weaponInfo.Rarity;
+            }
+            return 0;
+        }
+
+        public string GetDriveDiscSuitName(int suitId)
+        {
+            string suitIdStr = suitId.ToString();
+            if (_equipmentSuits.TryGetValue(suitIdStr, out var suitInfo) && !string.IsNullOrEmpty(suitInfo.Name))
+            {
+                return GetLocalizedText(suitInfo.Name);
+            }
+            return $"Suit_{suitId}";
+        }
+
+        public string GetDriveDiscSuitIconUrl(int suitId)
+        {
+            string suitIdStr = suitId.ToString();
+            if (_equipmentSuits.TryGetValue(suitIdStr, out var suitInfo) && !string.IsNullOrEmpty(suitInfo.Icon))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{suitInfo.Icon}";
+            }
+            return string.Empty;
+        }
+
+        public int GetDriveDiscRarity(int discId)
+        {
+            string discIdStr = discId.ToString();
+            if (_equipmentItems.TryGetValue(discIdStr, out var discInfo))
+            {
+                return discInfo.Rarity;
+            }
+            return 0;
+        }
+
+        public int GetDriveDiscSuitId(int discId)
+        {
+            string discIdStr = discId.ToString();
+            if (_equipmentItems.TryGetValue(discIdStr, out var discInfo))
+            {
+                return discInfo.SuitId;
+            }
+            return 0;
+        }
+
+        public string GetPropertyName(int propertyId)
+        {
+            string propertyIdStr = propertyId.ToString();
+            if (_properties.TryGetValue(propertyIdStr, out var propertyInfo) && !string.IsNullOrEmpty(propertyInfo.Name))
+            {
+                return propertyInfo.Name;
+            }
+            return $"Property_{propertyId}";
+        }
+
+        public string FormatPropertyValue(int propertyId, double value)
+        {
+            string propertyIdStr = propertyId.ToString();
+            if (_properties.TryGetValue(propertyIdStr, out var propertyInfo) && !string.IsNullOrEmpty(propertyInfo.Format))
+            {
+                try
+                {
+                    return string.Format(propertyInfo.Format, value);
+                }
+                catch
+                {
+                    return value.ToString();
+                }
+            }
+
+            bool isPercent = propertyId.ToString().EndsWith("2");
+            if (isPercent)
+            {
+                return $"{value:F1}%";
+            }
+            else
+            {
+                return $"{value:F0}";
+            }
+        }
+
+        public string GetTitleText(int titleId)
+        {
+            string titleIdStr = titleId.ToString();
+            if (_titles.TryGetValue(titleIdStr, out var titleInfo) && !string.IsNullOrEmpty(titleInfo.TitleText))
+            {
+                return GetLocalizedText(titleInfo.TitleText);
+            }
+            return $"Title_{titleId}";
+        }
+
+        public string GetMedalName(int medalId)
+        {
+            string medalIdStr = medalId.ToString();
+            if (_medals.TryGetValue(medalIdStr, out var medalInfo) && !string.IsNullOrEmpty(medalInfo.Name))
+            {
+                return GetLocalizedText(medalInfo.Name);
+            }
+            return $"Medal_{medalId}";
+        }
+
+        public string GetMedalIconUrl(int medalId)
+        {
+            string medalIdStr = medalId.ToString();
+            if (_medals.TryGetValue(medalIdStr, out var medalInfo) && !string.IsNullOrEmpty(medalInfo.Icon))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{medalInfo.Icon}";
+            }
+            return string.Empty;
+        }
+
+        public string GetNameCardIconUrl(int nameCardId)
+        {
+            string nameCardIdStr = nameCardId.ToString();
+            if (_namecards.TryGetValue(nameCardIdStr, out var nameCardInfo) && !string.IsNullOrEmpty(nameCardInfo.Icon))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{nameCardInfo.Icon}";
+            }
+            return string.Empty;
+        }
+
+        public string GetProfilePictureIconUrl(int profilePictureId)
+        {
+            string profilePictureIdStr = profilePictureId.ToString();
+            if (_pfps.TryGetValue(profilePictureIdStr, out var pfpInfo) && !string.IsNullOrEmpty(pfpInfo.Icon))
+            {
+                return $"{Constants.GetAssetBaseUrl(GameType)}{pfpInfo.Icon}";
+            }
+            return string.Empty;
+        }
+
+        public string GetSkillIconUrl(int agentId, SkillType skillType)
+        {
+            return string.Empty;
+        }
+
+        private ElementType MapElementNameToEnum(string elementName)
+        {
+            return elementName?.ToUpperInvariant() switch
+            {
+                "FIRE" => ElementType.Fire,
+                "ICE" => ElementType.Ice,
+                "FIREFROST" => ElementType.Ice,
+                "ELEC" => ElementType.Electric,
+                "ETHER" => ElementType.Ether,
+                "PHYSICS" => ElementType.Physical,
+                _ => ElementType.Unknown
+            };
+        }
+
+        private ProfessionType MapProfessionNameToEnum(string professionName)
+        {
+            return professionName?.ToUpperInvariant() switch
+            {
+                "ATTACK" => ProfessionType.Attack,
+                "STUN" => ProfessionType.Stun,
+                "ANOMALY" => ProfessionType.Anomaly,
+                "DEFENSE" => ProfessionType.Defense,
+                "SUPPORT" => ProfessionType.Support,
+                _ => ProfessionType.Unknown
+            };
+        }
+    }
+}

--- a/EnkaDotNet/Components/Genshin/Character.cs
+++ b/EnkaDotNet/Components/Genshin/Character.cs
@@ -30,7 +30,7 @@ namespace EnkaDotNet.Components.Genshin
 
                 if (isPercent)
                 {
-                    double percentValue = RawValue * 100;
+                    double percentValue = RawValue;
                     if (Math.Abs(percentValue - Math.Round(percentValue)) < 0.001)
                         value = $"{Math.Round(percentValue)}";
                     else

--- a/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
@@ -1,0 +1,76 @@
+﻿using EnkaDotNet.Enums.ZZZ;
+using EnkaDotNet.Utils.ZZZ;
+using System.Collections.Generic;
+
+namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZAgent
+    {
+        public int Id { get; internal set; }
+        public string Name { get; internal set; } = string.Empty;
+        public int Level { get; internal set; }
+        public int PromotionLevel { get; internal set; }
+        public int TalentLevel { get; internal set; }
+        public int SkinId { get; internal set; }
+        public List<int> CoreSkillEnhancements { get; internal set; } = new List<int>();
+        public int CoreSkillEnhancement { get; internal set; }
+        public List<int> TalentToggles { get; internal set; } = new List<int>();
+        public WEngineEffectState WeaponEffectState { get; internal set; }
+        public bool IsHidden { get; internal set; }
+        public List<int> ClaimedRewards { get; internal set; } = new List<int>();
+        public DateTimeOffset ObtainmentTimestamp { get; internal set; }
+
+        public ZZZWEngine? Weapon { get; internal set; }
+        public Dictionary<SkillType, int> SkillLevels { get; internal set; } = new Dictionary<SkillType, int>();
+        public List<ZZZDriveDisc> EquippedDiscs { get; internal set; } = new List<ZZZDriveDisc>();
+
+        public Rarity Rarity { get; internal set; }
+        public ProfessionType ProfessionType { get; internal set; }
+        public List<ElementType> ElementTypes { get; internal set; } = new List<ElementType>();
+        public string ImageUrl { get; internal set; } = string.Empty;
+        public string CircleIconUrl { get; internal set; } = string.Empty;
+
+        public Dictionary<StatType, double> Stats { get; internal set; } = new Dictionary<StatType, double>();
+
+        private Dictionary<string, ZZZStatValue> _cachedTotalStats;
+
+        public Dictionary<string, ZZZStatValue> GetAllStats()
+        {
+            if (_cachedTotalStats != null)
+                return _cachedTotalStats;
+
+            _cachedTotalStats = new Dictionary<string, ZZZStatValue>();
+            var rawTotals = ZZZStatsHelpers.CalculateAllTotalStats(this);
+
+            foreach (var stat in rawTotals)
+            {
+                bool isPercentage = ZZZStatsHelpers.IsDisplayPercentageStatForGroup(stat.Key);
+                bool isEnergyRegen = stat.Key == "Energy Regen";
+
+                _cachedTotalStats[stat.Key] = new ZZZStatValue(
+                    stat.Value,
+                    isPercentage,
+                    isEnergyRegen
+                );
+            }
+
+            return _cachedTotalStats;
+        }
+
+        public ZZZStatValue GetStat(string statName)
+        {
+            var stats = GetAllStats();
+            return stats.TryGetValue(statName, out var stat) ? stat : new ZZZStatValue(0);
+        }
+
+        public List<DriveDiscSetInfo> GetEquippedDiscSets()
+        {
+            return ZZZDriveDiscSetHelper.GetEquippedDiscSets(this);
+        }
+
+        public StatBreakdown GetStatBreakdown(string statName)
+        {
+            return ZZZStatsHelpers.GetStatSourceBreakdown(this, statName);
+        }
+    }
+}

--- a/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
@@ -1,0 +1,24 @@
+﻿using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZDriveDisc
+    {
+        public string Uid { get; internal set; } = string.Empty;
+        public int Id { get; internal set; }
+        public int Level { get; internal set; }
+        public int BreakLevel { get; internal set; }
+        public bool IsLocked { get; internal set; }
+        public bool IsAvailable { get; internal set; }
+        public bool IsTrash { get; internal set; }
+        public DriveDiscSlot Slot { get; internal set; }
+
+        public Rarity Rarity { get; internal set; }
+        public int SuitId { get; internal set; }
+        public string SuitName { get; internal set; } = string.Empty;
+        public string IconUrl { get; internal set; } = string.Empty;
+
+        public ZZZStat MainStat { get; internal set; } = new ZZZStat();
+        public List<ZZZStat> SubStats { get; internal set; } = new List<ZZZStat>();
+    }
+}

--- a/EnkaDotNet/Components/ZZZ/ZZZPlayerInfo.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZPlayerInfo.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZPlayerInfo
+    {
+        public string Uid { get; internal set; } = string.Empty;
+        public string TTL { get; internal set; } = string.Empty;
+
+        public string Nickname { get; internal set; } = string.Empty;
+        public int Level { get; internal set; }
+        public string Signature { get; internal set; } = string.Empty;
+        public int ProfilePictureId { get; internal set; }
+        public string ProfilePictureIcon { get; internal set; } = string.Empty;
+        public int TitleId { get; internal set; }
+        public string TitleText { get; internal set; } = string.Empty;
+        public int NameCardId { get; internal set; }
+        public string NameCardIcon { get; internal set; } = string.Empty;
+        public int MainCharacterId { get; internal set; }
+
+        public List<ZZZMedal> Medals { get; internal set; } = new List<ZZZMedal>();
+
+        public List<ZZZAgent> ShowcaseAgents { get; internal set; } = new List<ZZZAgent>();
+    }
+
+    public class ZZZMedal
+    {
+        public MedalType Type { get; internal set; }
+        public int Value { get; internal set; }
+        public string Icon { get; internal set; } = string.Empty;
+        public string Name { get; internal set; } = string.Empty;
+    }
+}

--- a/EnkaDotNet/Components/ZZZ/ZZZStat.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZStat.cs
@@ -1,0 +1,20 @@
+﻿using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZStat
+    {
+        public StatType Type { get; set; }
+        public double Value { get; set; }
+        public double FormattedValue { get; set; }
+        public int Level { get; set; }
+        public bool IsPercentage { get; internal set; }
+
+        public string DisplayValue => IsPercentage ? $"{Value:F1}%" : $"{(int)Value}";
+
+        public override string ToString()
+        {
+            return $"{Type}: {DisplayValue}";
+        }
+    }
+}

--- a/EnkaDotNet/Components/ZZZ/ZZZStatValue.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZStatValue.cs
@@ -1,0 +1,32 @@
+﻿namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZStatValue
+    {
+        public double Raw { get; set; }
+        public string Formatted { get; set; }
+        public bool IsPercentage { get; set; }
+        public bool IsEnergyRegen { get; set; }
+
+        public ZZZStatValue(double raw, bool isPercentage = false, bool isEnergyRegen = false)
+        {
+            Raw = raw;
+            IsPercentage = isPercentage;
+            IsEnergyRegen = isEnergyRegen;
+
+            if (isEnergyRegen)
+            {
+                Formatted = $"{raw:F2}";
+            }
+            else if (isPercentage)
+            {
+                Formatted = $"{raw:F1}%";
+            }
+            else
+            {
+                Formatted = $"{(int)raw}";
+            }
+        }
+
+        public override string ToString() => Formatted;
+    }
+}

--- a/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
@@ -1,0 +1,23 @@
+﻿using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Components.ZZZ
+{
+    public class ZZZWEngine
+    {
+        public string Uid { get; internal set; } = string.Empty;
+        public int Id { get; internal set; }
+        public int Level { get; internal set; }
+        public int BreakLevel { get; internal set; }
+        public int UpgradeLevel { get; internal set; }
+        public bool IsAvailable { get; internal set; }
+        public bool IsLocked { get; internal set; }
+
+        public string Name { get; internal set; } = string.Empty;
+        public Rarity Rarity { get; internal set; }
+        public ProfessionType ProfessionType { get; internal set; }
+        public string ImageUrl { get; internal set; } = string.Empty;
+
+        public ZZZStat MainStat { get; internal set; } = new ZZZStat();
+        public ZZZStat SecondaryStat { get; internal set; } = new ZZZStat();
+    }
+}

--- a/EnkaDotNet/EnkaClient.cs
+++ b/EnkaDotNet/EnkaClient.cs
@@ -7,17 +7,18 @@ using EnkaDotNet.Utils.Common;
 using EnkaDotNet.Utils;
 using EnkaDotNet.Exceptions;
 using EnkaDotNet.Utils.Genshin;
+using EnkaDotNet.Utils.ZZZ;
+using EnkaDotNet.Assets.ZZZ;
 
 namespace EnkaDotNet
 {
-    /// <summary>
-    /// Client for accessing Enka Network API data
-    /// </summary>
-    public class EnkaClient : IDisposable
+    public partial class EnkaClient : IDisposable
     {
         private readonly HttpHelper _httpHelper;
         private readonly DataMapper? _dataMapper;
+        private readonly ZZZDataMapper? _zzzDataMapper;
         private readonly IGenshinAssets? _genshinAssets;
+        private readonly IZZZAssets? _zzzAssets;
         private readonly EnkaClientOptions _options;
         private bool _disposed = false;
 
@@ -45,6 +46,10 @@ namespace EnkaDotNet
                 case GameType.Genshin:
                     _genshinAssets = AssetsFactory.CreateGenshin(_options.Language);
                     _dataMapper = new DataMapper(_genshinAssets);
+                    break;
+                case GameType.ZZZ:
+                    _zzzAssets = new ZZZAssets(_options.Language);
+                    _zzzDataMapper = new ZZZDataMapper(_zzzAssets);
                     break;
             }
         }

--- a/EnkaDotNet/EnkaClientZZZExtensions.cs
+++ b/EnkaDotNet/EnkaClientZZZExtensions.cs
@@ -1,0 +1,75 @@
+﻿using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Enums;
+using EnkaDotNet.Exceptions;
+using EnkaDotNet.Models.ZZZ;
+using EnkaDotNet.Utils;
+
+namespace EnkaDotNet
+{
+    public partial class EnkaClient
+    {
+        public async Task<ZZZApiResponse?> GetRawZZZUserResponse(int uid, bool bypassCache = false, CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (uid <= 0) throw new ArgumentException("UID must be a positive integer.", nameof(uid));
+
+            EnsureZZZGameType();
+
+            string endpoint = string.Format(Constants.GetUserInfoEndpointFormat(_options.GameType), uid);
+            var response = await _httpHelper.Get<ZZZApiResponse>(endpoint, bypassCache, cancellationToken);
+
+            if (response != null && response.PlayerInfo == null)
+            {
+                throw new ProfilePrivateException(uid, "Profile data retrieved but player info is missing, profile might be private or UID invalid.");
+            }
+
+            return response;
+        }
+
+        public async Task<ZZZPlayerInfo> GetZZZPlayerInfo(int uid, bool bypassCache = false, CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            EnsureZZZGameType();
+
+            var rawResponse = await GetRawZZZUserResponse(uid, bypassCache, cancellationToken);
+
+            if (rawResponse == null)
+            {
+                throw new EnkaNetworkException($"Failed to retrieve valid PlayerInfo for UID {uid}. Response was null.");
+            }
+
+            return _zzzDataMapper!.MapPlayerInfo(rawResponse);
+        }
+
+        public async Task<List<ZZZAgent>> GetZZZAgents(int uid, bool bypassCache = false, CancellationToken cancellationToken = default)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            EnsureZZZGameType();
+
+            var rawResponse = await GetRawZZZUserResponse(uid, bypassCache, cancellationToken);
+
+            if (rawResponse?.PlayerInfo?.ShowcaseDetail?.AvatarList == null)
+            {
+                throw new EnkaNetworkException($"Failed to retrieve agent list for UID {uid}. Response or AvatarList was null.");
+            }
+
+            var agents = new List<ZZZAgent>();
+            foreach (var avatarModel in rawResponse.PlayerInfo.ShowcaseDetail.AvatarList)
+            {
+                agents.Add(_zzzDataMapper!.MapAgent(avatarModel));
+            }
+
+            return agents;
+        }
+
+        private void EnsureZZZGameType()
+        {
+            if (_options.GameType != GameType.ZZZ || _zzzDataMapper == null || _zzzAssets == null)
+            {
+                throw new NotSupportedException(
+                    "This operation is only available for Zenless Zone Zero. " +
+                    $"Current game type: {_options.GameType}");
+            }
+        }
+    }
+}

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
         <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-        <Version>1.0.4</Version>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/EnkaDotNet/Enums/GameType.cs
+++ b/EnkaDotNet/Enums/GameType.cs
@@ -6,5 +6,8 @@ namespace EnkaDotNet.Enums
     {
         [Description("Genshin Impact")]
         Genshin = 0,
+
+        [Description("Zenless Zone Zero")]
+        ZZZ = 1,
     }
 }

--- a/EnkaDotNet/Enums/ZZZ/DriveDiscSlot.cs
+++ b/EnkaDotNet/Enums/ZZZ/DriveDiscSlot.cs
@@ -1,0 +1,13 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum DriveDiscSlot
+    {
+        Unknown = 0,
+        Slot1 = 1,
+        Slot2 = 2,
+        Slot3 = 3,
+        Slot4 = 4,
+        Slot5 = 5,
+        Slot6 = 6
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/ElementType.cs
+++ b/EnkaDotNet/Enums/ZZZ/ElementType.cs
@@ -1,0 +1,12 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum ElementType
+    {
+        Unknown = 0,
+        Physical,
+        Fire,
+        Ice,
+        Electric,
+        Ether
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/MedalType.cs
+++ b/EnkaDotNet/Enums/ZZZ/MedalType.cs
@@ -1,0 +1,11 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum MedalType
+    {
+        Unknown = 0,
+        ShiyuDefense = 1,        
+        SimulatedBattleTower = 2,
+        DeadlyAssault = 3,        
+        LastStand = 4           
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/ProfessionType.cs
+++ b/EnkaDotNet/Enums/ZZZ/ProfessionType.cs
@@ -1,0 +1,12 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum ProfessionType
+    {
+        Unknown = 0,
+        Attack,
+        Stun,
+        Anomaly,
+        Defense,
+        Support
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/Rarity.cs
+++ b/EnkaDotNet/Enums/ZZZ/Rarity.cs
@@ -1,0 +1,10 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum Rarity
+    {
+        Unknown = 0,
+        B = 2,
+        A = 3,
+        S = 4 
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/SkillType.cs
+++ b/EnkaDotNet/Enums/ZZZ/SkillType.cs
@@ -1,0 +1,12 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum SkillType
+    {
+        BasicAttack = 0, 
+        SpecialAttack = 1,
+        Dash = 2,        
+        Ultimate = 3,   
+        CoreSkill = 5,  
+        Assist = 6   
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/StatType.cs
+++ b/EnkaDotNet/Enums/ZZZ/StatType.cs
@@ -1,0 +1,62 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum StatType
+    {
+        None = 0,
+
+        // HP Stats
+        HPBase = 11101,          // HP [Base]
+        HPPercent = 11102,       // HP%
+        HPFlat = 11103,          // HP [Flat]
+
+        // ATK Stats
+        ATKBase = 12101,         // ATK [Base]
+        ATKPercent = 12102,      // ATK%
+        ATKFlat = 12103,         // ATK [Flat]
+
+        // Impact Stats
+        ImpactBase = 12201,      // Impact [Base]
+        ImpactPercent = 12202,   // Impact%
+
+        // DEF Stats
+        DefBase = 13101,         // Def [Base]
+        DefPercent = 13102,      // Def%
+        DefFlat = 13103,         // Def [Flat]
+
+        // Crit Stats
+        CritRateBase = 20101,    // Crit Rate [Base]
+        CritRateFlat = 20103,    // Crit Rate [Flat]
+        CritDMGBase = 21101,     // Crit DMG [Base]
+        CritDMGFlat = 21103,     // Crit DMG [Flat]
+
+        // Penetration Stats
+        PenRatioBase = 23101,    // Pen Ratio [Base]
+        PenRatioFlat = 23103,    // Pen Ratio [Flat]
+        PENBase = 23201,         // PEN [Base]
+        PENFlat = 23203,         // PEN [Flat]
+
+        // Energy Stats
+        EnergyRegenBase = 30501,    // Energy Regen [Base]
+        EnergyRegenPercent = 30502, // Energy Regen%
+        EnergyRegenFlat = 30503,    // Energy Regen [Flat]
+
+        // Anomaly Stats
+        AnomalyProficiencyBase = 31201, // Anomaly Proficiency [Base]
+        AnomalyProficiencyFlat = 31203, // Anomaly Proficiency [Flat]
+        AnomalyMasteryBase = 31401,     // Anomaly Mastery [Base]
+        AnomalyMasteryPercent = 31402,  // Anomaly Mastery%
+        AnomalyMasteryFlat = 31403,     // Anomaly Mastery [Flat]
+
+        // Elemental Damage Bonuses
+        PhysicalDMGBonusBase = 31501, // Physical DMG Bonus [Base]
+        PhysicalDMGBonusFlat = 31503, // Physical DMG Bonus [Flat]
+        FireDMGBonusBase = 31601,     // Fire DMG Bonus [Base]
+        FireDMGBonusFlat = 31603,     // Fire DMG Bonus [Flat]
+        IceDMGBonusBase = 31701,      // Ice DMG Bonus [Base]
+        IceDMGBonusFlat = 31703,      // Ice DMG Bonus [Flat]
+        ElectricDMGBonusBase = 31801, // Electric DMG Bonus [Base]
+        ElectricDMGBonusFlat = 31803, // Electric DMG Bonus [Flat]
+        EtherDMGBonusBase = 31901,    // Ether DMG Bonus [Base]
+        EtherDMGBonusFlat = 31903     // Ether DMG Bonus [Flat]
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
+++ b/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
@@ -1,0 +1,9 @@
+﻿namespace EnkaDotNet.Enums.ZZZ
+{
+    public enum WEngineEffectState
+    {
+        None = 0,
+        Off = 1,
+        On = 2 
+    }
+}

--- a/EnkaDotNet/Models/ZZZ/ZZZApiResponse.cs
+++ b/EnkaDotNet/Models/ZZZ/ZZZApiResponse.cs
@@ -1,0 +1,58 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Models.ZZZ
+{
+    public class ZZZApiResponse
+    {
+        [JsonPropertyName("PlayerInfo")]
+        public ZZZPlayerInfoModel? PlayerInfo { get; set; }
+
+        [JsonPropertyName("uid")]
+        public string? Uid { get; set; }
+
+        [JsonPropertyName("ttl")]
+        public int Ttl { get; set; }
+    }
+
+    public class ZZZPlayerInfoModel
+    {
+        [JsonPropertyName("ShowcaseDetail")]
+        public ZZZShowcaseDetailModel? ShowcaseDetail { get; set; }
+
+        [JsonPropertyName("SocialDetail")]
+        public ZZZSocialDetailModel? SocialDetail { get; set; }
+
+        [JsonPropertyName("Desc")]
+        public string? Desc { get; set; }
+    }
+
+    public class ZZZShowcaseDetailModel
+    {
+        [JsonPropertyName("AvatarList")]
+        public List<ZZZAvatarModel>? AvatarList { get; set; }
+    }
+
+    public class ZZZSocialDetailModel
+    {
+        [JsonPropertyName("MedalList")]
+        public List<ZZZMedalModel>? MedalList { get; set; }
+
+        [JsonPropertyName("ProfileDetail")]
+        public ZZZProfileDetailModel? ProfileDetail { get; set; }
+
+        [JsonPropertyName("Desc")]
+        public string? Desc { get; set; }
+    }
+
+    public class ZZZMedalModel
+    {
+        [JsonPropertyName("Value")]
+        public int Value { get; set; }
+
+        [JsonPropertyName("MedalType")]
+        public int MedalType { get; set; }
+
+        [JsonPropertyName("MedalIcon")]
+        public int MedalIcon { get; set; }
+    }
+}

--- a/EnkaDotNet/Models/ZZZ/ZZZAvatarModel.cs
+++ b/EnkaDotNet/Models/ZZZ/ZZZAvatarModel.cs
@@ -1,0 +1,145 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Models.ZZZ
+{
+    public class ZZZAvatarModel
+    {
+        [JsonPropertyName("Id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("Level")]
+        public int Level { get; set; }
+
+        [JsonPropertyName("PromotionLevel")]
+        public int PromotionLevel { get; set; }
+
+        [JsonPropertyName("Exp")]
+        public int Exp { get; set; }
+
+        [JsonPropertyName("SkinId")]
+        public int SkinId { get; set; }
+
+        [JsonPropertyName("TalentLevel")]
+        public int TalentLevel { get; set; }
+
+        [JsonPropertyName("CoreSkillEnhancement")]
+        public int CoreSkillEnhancement { get; set; }
+
+        [JsonPropertyName("WeaponUid")]
+        public int WeaponUid { get; set; }
+
+        [JsonPropertyName("ObtainmentTimestamp")]
+        public long ObtainmentTimestamp { get; set; }
+
+        [JsonPropertyName("WeaponEffectState")]
+        public int WeaponEffectState { get; set; }
+
+        [JsonPropertyName("TalentToggleList")]
+        public List<bool>? TalentToggleList { get; set; }
+
+        [JsonPropertyName("ClaimedRewardList")]
+        public List<int>? ClaimedRewardList { get; set; }
+
+        [JsonPropertyName("IsHidden")]
+        public bool IsHidden { get; set; }
+
+        [JsonPropertyName("Weapon")]
+        public ZZZWeaponModel? Weapon { get; set; }
+
+        [JsonPropertyName("SkillLevelList")]
+        public List<ZZZSkillLevelModel>? SkillLevelList { get; set; }
+
+        [JsonPropertyName("EquippedList")]
+        public List<ZZZEquippedItemModel>? EquippedList { get; set; }
+    }
+
+    public class ZZZSkillLevelModel
+    {
+        [JsonPropertyName("Level")]
+        public int Level { get; set; }
+
+        [JsonPropertyName("Index")]
+        public int Index { get; set; }
+    }
+
+    public class ZZZEquippedItemModel
+    {
+        [JsonPropertyName("Slot")]
+        public int Slot { get; set; }
+
+        [JsonPropertyName("Equipment")]
+        public ZZZEquipmentModel? Equipment { get; set; }
+    }
+
+    public class ZZZEquipmentModel
+    {
+        [JsonPropertyName("RandomPropertyList")]
+        public List<ZZZPropertyModel>? RandomPropertyList { get; set; }
+
+        [JsonPropertyName("MainPropertyList")]
+        public List<ZZZPropertyModel>? MainPropertyList { get; set; }
+
+        [JsonPropertyName("IsAvailable")]
+        public bool IsAvailable { get; set; }
+
+        [JsonPropertyName("IsLocked")]
+        public bool IsLocked { get; set; }
+
+        [JsonPropertyName("IsTrash")]
+        public bool IsTrash { get; set; }
+
+        [JsonPropertyName("Id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("Uid")]
+        public int Uid { get; set; }
+
+        [JsonPropertyName("Level")]
+        public int Level { get; set; }
+
+        [JsonPropertyName("BreakLevel")]
+        public int BreakLevel { get; set; }
+
+        [JsonPropertyName("Exp")]
+        public int Exp { get; set; }
+    }
+
+    public class ZZZPropertyModel
+    {
+        [JsonPropertyName("PropertyId")]
+        public int PropertyId { get; set; }
+
+        [JsonPropertyName("PropertyLevel")]
+        public int PropertyLevel { get; set; }
+
+        [JsonPropertyName("PropertyValue")]
+        public int PropertyValue { get; set; }
+    }
+
+    public class ZZZWeaponModel
+    {
+        [JsonPropertyName("IsAvailable")]
+        public bool IsAvailable { get; set; }
+
+        [JsonPropertyName("IsLocked")]
+        public bool IsLocked { get; set; }
+
+        [JsonPropertyName("Id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("Uid")]
+        public int Uid { get; set; }
+
+        [JsonPropertyName("Level")]
+        public int Level { get; set; }
+
+        [JsonPropertyName("BreakLevel")]
+        public int BreakLevel { get; set; }
+
+        [JsonPropertyName("Exp")]
+        public int Exp { get; set; }
+
+        [JsonPropertyName("UpgradeLevel")]
+        public int UpgradeLevel { get; set; }
+    }
+}

--- a/EnkaDotNet/Models/ZZZ/ZZZProfileDetailModel.cs
+++ b/EnkaDotNet/Models/ZZZ/ZZZProfileDetailModel.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json.Serialization;
+
+namespace EnkaDotNet.Models.ZZZ
+{
+    public class ZZZProfileDetailModel
+    {
+        [JsonPropertyName("Nickname")]
+        public string? Nickname { get; set; }
+
+        [JsonPropertyName("AvatarId")]
+        public int AvatarId { get; set; }
+
+        [JsonPropertyName("Uid")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public long Uid { get; set; }  // Changed from string to long to handle numeric UIDs
+
+        [JsonPropertyName("Level")]
+        public int Level { get; set; }
+
+        [JsonPropertyName("Title")]
+        public int Title { get; set; }
+
+        [JsonPropertyName("ProfileId")]
+        public int ProfileId { get; set; }
+
+        [JsonPropertyName("PlatformType")]
+        public int PlatformType { get; set; }
+
+        [JsonPropertyName("CallingCardId")]
+        public int CallingCardId { get; set; }
+    }
+}

--- a/EnkaDotNet/Utils/Constants.cs
+++ b/EnkaDotNet/Utils/Constants.cs
@@ -8,6 +8,9 @@ namespace EnkaDotNet.Utils
         private const string DEFAULT_GENSHIN_API_URL = "https://enka.network/api/";
         private const string DEFAULT_GENSHIN_ASSET_URL = "https://enka.network/ui/";
 
+        private const string DEFAULT_ZZZ_API_URL = "https://enka.network/api/zzz/";
+        private const string DEFAULT_ZZZ_ASSET_URL = "https://enka.network";
+
         public const string DefaultUserAgent = "EnkaDotNet/1.0";
 
         public static string GetBaseUrl(GameType gameType)
@@ -15,6 +18,7 @@ namespace EnkaDotNet.Utils
             return gameType switch
             {
                 GameType.Genshin => DEFAULT_GENSHIN_API_URL,
+                GameType.ZZZ => DEFAULT_ZZZ_API_URL,
                 _ => throw new NotSupportedException($"Game type {gameType} is not supported.")
             };
         }
@@ -24,6 +28,7 @@ namespace EnkaDotNet.Utils
             return gameType switch
             {
                 GameType.Genshin => "uid/{0}",
+                GameType.ZZZ => "uid/{0}",
                 _ => throw new NotSupportedException($"Game type {gameType} is not supported.")
             };
         }
@@ -33,13 +38,14 @@ namespace EnkaDotNet.Utils
             return gameType switch
             {
                 GameType.Genshin => DEFAULT_GENSHIN_ASSET_URL,
+                GameType.ZZZ => DEFAULT_ZZZ_ASSET_URL,
                 _ => throw new NotSupportedException($"Game type {gameType} is not supported.")
             };
         }
 
         public static bool IsGameTypeSupported(GameType gameType)
         {
-            return gameType == GameType.Genshin;
+            return gameType == GameType.Genshin || gameType == GameType.ZZZ;
         }
     }
 }

--- a/EnkaDotNet/Utils/ZZZ/ZZZDataMapper.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZDataMapper.cs
@@ -1,0 +1,255 @@
+﻿using EnkaDotNet.Models.ZZZ;
+using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Utils.ZZZ
+{
+    public class ZZZDataMapper
+    {
+        private readonly IZZZAssets _assets;
+        private readonly ZZZStatsCalculator _statsCalculator;
+
+        public ZZZDataMapper(IZZZAssets assets)
+        {
+            _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _statsCalculator = new ZZZStatsCalculator(assets);
+        }
+
+        public ZZZPlayerInfo MapPlayerInfo(ZZZApiResponse response)
+        {
+            if (response == null) throw new ArgumentNullException(nameof(response));
+            if (response.PlayerInfo == null) throw new ArgumentException("PlayerInfo is null", nameof(response));
+
+            var profileDetail = response.PlayerInfo.SocialDetail?.ProfileDetail;
+            if (profileDetail == null) throw new ArgumentException("ProfileDetail is null", nameof(response));
+
+            var playerInfo = new ZZZPlayerInfo
+            {
+                Uid = response.Uid ?? profileDetail.Uid.ToString(),
+                TTL = response.Ttl.ToString(),
+                Nickname = profileDetail.Nickname ?? "Unknown",
+                Level = profileDetail.Level,
+                Signature = response.PlayerInfo.SocialDetail?.Desc ?? "",
+                ProfilePictureId = profileDetail.ProfileId,
+                ProfilePictureIcon = _assets.GetProfilePictureIconUrl(profileDetail.ProfileId),
+                TitleId = profileDetail.Title,
+                TitleText = _assets.GetTitleText(profileDetail.Title),
+                NameCardId = profileDetail.CallingCardId,
+                NameCardIcon = _assets.GetNameCardIconUrl(profileDetail.CallingCardId),
+                MainCharacterId = profileDetail.AvatarId
+            };
+
+            if (response.PlayerInfo.SocialDetail?.MedalList != null)
+            {
+                foreach (var medalModel in response.PlayerInfo.SocialDetail.MedalList)
+                {
+                    playerInfo.Medals.Add(new ZZZMedal
+                    {
+                        Type = (MedalType)medalModel.MedalType,
+                        Value = medalModel.Value,
+                        Icon = _assets.GetMedalIconUrl(medalModel.MedalIcon),
+                        Name = _assets.GetMedalName(medalModel.MedalIcon)
+                    });
+                }
+            }
+
+            if (response.PlayerInfo.ShowcaseDetail?.AvatarList != null)
+            {
+                foreach (var avatarModel in response.PlayerInfo.ShowcaseDetail.AvatarList)
+                {
+                    var agent = MapAgent(avatarModel);
+                    playerInfo.ShowcaseAgents.Add(agent);
+                }
+            }
+
+            return playerInfo;
+        }
+
+        public ZZZAgent MapAgent(ZZZAvatarModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            var agent = new ZZZAgent
+            {
+                Id = model.Id,
+                Name = _assets.GetAgentName(model.Id),
+                Level = model.Level,
+                PromotionLevel = model.PromotionLevel,
+                TalentLevel = model.TalentLevel,
+                CoreSkillEnhancement = model.CoreSkillEnhancement,
+                SkinId = model.SkinId,
+                WeaponEffectState = (WEngineEffectState)model.WeaponEffectState,
+                IsHidden = model.IsHidden,
+                ObtainmentTimestamp = DateTimeOffset.FromUnixTimeSeconds(model.ObtainmentTimestamp),
+                ImageUrl = _assets.GetAgentIconUrl(model.Id),
+                CircleIconUrl = _assets.GetAgentCircleIconUrl(model.Id),
+                Rarity = (Rarity)_assets.GetAgentRarity(model.Id),
+                ProfessionType = _assets.GetAgentProfessionType(model.Id),
+                ElementTypes = FilterUnknownElements(_assets.GetAgentElements(model.Id))
+            };
+
+            agent.Stats = _statsCalculator.CalculateAgentBaseStats(
+                model.Id,
+                model.Level,
+                model.PromotionLevel,
+                model.CoreSkillEnhancement
+            );
+
+            agent.CoreSkillEnhancements.Clear();
+            if (model.CoreSkillEnhancement > 0)
+            {
+                for (int i = 0; i < model.CoreSkillEnhancement; i++)
+                {
+                    agent.CoreSkillEnhancements.Add(i);
+                }
+            }
+
+
+            agent.TalentToggles.Clear();
+            if (model.TalentToggleList != null)
+            {
+                for (int i = 0; i < model.TalentToggleList.Count; i++)
+                {
+                    if (model.TalentToggleList[i])
+                    {
+                        agent.TalentToggles.Add(i);
+                    }
+                }
+            }
+
+            agent.ClaimedRewards.Clear();
+            if (model.ClaimedRewardList != null)
+            {
+                agent.ClaimedRewards.AddRange(model.ClaimedRewardList);
+            }
+
+            if (model.Weapon != null)
+            {
+                agent.Weapon = MapWeapon(model.Weapon);
+            }
+
+            agent.SkillLevels.Clear();
+            if (model.SkillLevelList != null)
+            {
+                foreach (var skillLevel in model.SkillLevelList)
+                {
+                    if (Enum.IsDefined(typeof(SkillType), skillLevel.Index))
+                    {
+                        agent.SkillLevels[(SkillType)skillLevel.Index] = skillLevel.Level;
+                    }
+                }
+            }
+
+            agent.EquippedDiscs.Clear();
+            if (model.EquippedList != null)
+            {
+                foreach (var equippedItem in model.EquippedList)
+                {
+                    if (equippedItem.Equipment != null)
+                    {
+                        var driveDisc = MapDriveDisc(equippedItem.Equipment, equippedItem.Slot);
+                        agent.EquippedDiscs.Add(driveDisc);
+                    }
+                }
+            }
+
+
+            return agent;
+        }
+
+        public ZZZWEngine MapWeapon(ZZZWeaponModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            var weapon = new ZZZWEngine
+            {
+                Uid = model.Uid.ToString(),
+                Id = model.Id,
+                Level = model.Level,
+                BreakLevel = model.BreakLevel,
+                UpgradeLevel = model.UpgradeLevel,
+                IsAvailable = model.IsAvailable,
+                IsLocked = model.IsLocked,
+                Name = _assets.GetWeaponName(model.Id),
+                Rarity = (Rarity)_assets.GetWeaponRarity(model.Id),
+                ProfessionType = _assets.GetWeaponType(model.Id),
+                ImageUrl = _assets.GetWeaponIconUrl(model.Id)
+            };
+
+            var (mainStat, secondaryStat) = _statsCalculator.CalculateWeaponStats(model.Id, model.Level, model.BreakLevel);
+            weapon.MainStat = mainStat;
+            weapon.SecondaryStat = secondaryStat;
+
+            return weapon;
+        }
+
+        public ZZZDriveDisc MapDriveDisc(ZZZEquipmentModel model, int slot)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            int suitId = _assets.GetDriveDiscSuitId(model.Id);
+            int rarityValue = _assets.GetDriveDiscRarity(model.Id);
+            Rarity rarity = (Rarity)rarityValue;
+
+            var driveDisc = new ZZZDriveDisc
+            {
+                Uid = model.Uid.ToString(),
+                Id = model.Id,
+                Level = model.Level,
+                BreakLevel = model.BreakLevel,
+                IsLocked = model.IsLocked,
+                IsAvailable = model.IsAvailable,
+                IsTrash = model.IsTrash,
+                Slot = (DriveDiscSlot)slot,
+                Rarity = rarity,
+                SuitId = suitId,
+                SuitName = _assets.GetDriveDiscSuitName(suitId),
+                IconUrl = _assets.GetDriveDiscSuitIconUrl(suitId)
+            };
+
+            if (model.MainPropertyList != null && model.MainPropertyList.Count > 0)
+            {
+                var mainProperty = model.MainPropertyList[0];
+                driveDisc.MainStat = _statsCalculator.CalculateDriveDiscMainStat(
+                    mainProperty.PropertyId,
+                    mainProperty.PropertyValue,
+                    model.Level,
+                    mainProperty.PropertyLevel,
+                    driveDisc.Rarity
+                );
+            }
+            else
+            {
+                driveDisc.MainStat = new ZZZStat { Type = StatType.None };
+            }
+
+
+            driveDisc.SubStats.Clear();
+            if (model.RandomPropertyList != null)
+            {
+                foreach (var property in model.RandomPropertyList)
+                {
+                    var subStat = _statsCalculator.CreateStatWithProperScaling(
+                        property.PropertyId,
+                        property.PropertyValue,
+                        property.PropertyLevel
+                    );
+                    driveDisc.SubStats.Add(subStat);
+                }
+            }
+
+            return driveDisc;
+        }
+
+        private List<ElementType> FilterUnknownElements(List<ElementType> elements)
+        {
+            if (elements == null || elements.Count == 0)
+                return new List<ElementType> { ElementType.Unknown }; // Return Unknown if empty
+
+            var validElements = elements.Where(e => e != ElementType.Unknown).ToList();
+
+            return validElements.Count > 0 ? validElements : elements;
+        }
+    }
+}

--- a/EnkaDotNet/Utils/ZZZ/ZZZDriveDiscSetHelper.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZDriveDiscSetHelper.cs
@@ -1,0 +1,113 @@
+﻿using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Enums.ZZZ;
+
+namespace EnkaDotNet.Utils.ZZZ
+{
+    public static class ZZZDriveDiscSetHelper
+    {
+        private const int MIN_SET_PIECES = 2;
+        private static readonly IZZZAssets assets = new ZZZAssets();
+
+        public static List<DriveDiscSetInfo> GetEquippedDiscSets(this ZZZAgent agent)
+        {
+            var result = new List<DriveDiscSetInfo>();
+
+            if (agent.EquippedDiscs.Count < MIN_SET_PIECES)
+                return result;
+
+            var discSets = agent.EquippedDiscs
+                .GroupBy(d => d.SuitId)
+                .Where(g => g.Count() >= MIN_SET_PIECES)
+                .Select(g => new { SuitId = g.Key, Count = g.Count(), Discs = g.ToList() })
+                .ToList();
+
+            foreach (var set in discSets)
+            {
+                var firstDisc = set.Discs.First();
+                var suitInfo = assets.GetDiscSetInfo(set.SuitId.ToString());
+
+                var setInfo = new DriveDiscSetInfo
+                {
+                    SuitId = set.SuitId,
+                    SuitName = firstDisc.SuitName,
+                    PieceCount = set.Count,
+                    Discs = set.Discs
+                };
+
+                if (suitInfo?.SetBonusProps != null && suitInfo.SetBonusProps.Any())
+                {
+                    var bonusDescriptions = new List<string>();
+
+                    foreach (var prop in suitInfo.SetBonusProps)
+                    {
+                        string formattedValue = string.Empty; 
+                        if (int.TryParse(prop.Key, out int propId) && Enum.IsDefined(typeof(StatType), propId))
+                        {
+                            string propName = assets.GetPropertyName(propId);
+                            double rawValue = prop.Value;
+                            StatType statType = (StatType)propId;
+
+                            if (ZZZStatsHelpers.IsDisplayPercentageStat(statType))
+                            {
+                                formattedValue = $"{(rawValue / 100):F0}%";
+                            }
+                            else
+                            {
+                                formattedValue = $"{Math.Round(rawValue):F0}";
+                                if (ZZZStatsHelpers.IsDisplayPercentageStat(statType))
+                                {
+                                    formattedValue = $"{rawValue:F1}%";
+                                }
+                                else
+                                {
+                                    formattedValue = $"{rawValue:F0}";
+                                }
+                            }
+                            bonusDescriptions.Add($"{propName} +{formattedValue}");
+                        }
+                    }
+                    setInfo.BonusDescription = string.Join(", ", bonusDescriptions);
+                    setInfo.BonusStats = suitInfo.SetBonusProps
+                        .Where(prop => int.TryParse(prop.Key, out int propId) && Enum.IsDefined(typeof(StatType), propId))
+                        .Select(prop =>
+                        {
+                            var statType = (StatType)int.Parse(prop.Key);
+                            return new BonusStats
+                            {
+                                StatType = statType,
+                                Value = ZZZStatsHelpers.IsDisplayPercentageStat(statType) ? $"{(prop.Value / 100):F0}%" : $"{Math.Round((double)prop.Value, MidpointRounding.AwayFromZero):F0}",
+                                Description = setInfo.BonusDescription
+                            };
+                            
+                        }).ToList();
+                }
+                else
+                {
+                    setInfo.BonusDescription = "No set bonus information available";
+                }
+
+                result.Add(setInfo);
+            }
+
+            return result;
+        }
+    }
+
+    public class DriveDiscSetInfo
+    {
+        public int SuitId { get; set; }
+        public string SuitName { get; set; } = string.Empty;
+        public int PieceCount { get; set; }
+        public List<ZZZDriveDisc> Discs { get; set; } = new List<ZZZDriveDisc>();
+        public List<BonusStats> BonusStats { get; set; } = new List<BonusStats>();
+        public string BonusDescription { get; set; } = string.Empty;
+    }
+
+    public class BonusStats
+    {
+        public StatType StatType { get; set; }
+        public string Value { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+    }

--- a/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
@@ -1,0 +1,213 @@
+﻿using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Enums.ZZZ;
+using System;
+using System.Collections.Generic;
+
+namespace EnkaDotNet.Utils.ZZZ
+{
+    public class ZZZStatsCalculator
+    {
+        private readonly IZZZAssets _assets;
+        private Dictionary<string, double> _calculationCache = new Dictionary<string, double>();
+
+        public ZZZStatsCalculator(IZZZAssets assets)
+        {
+            _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+        }
+
+        public Dictionary<StatType, double> CalculateAgentBaseStats(int agentId, int level, int promotionLevel, int coreSkillEnhancement)
+        {
+            string cacheKey = $"agent_{agentId}_{level}_{promotionLevel}_{coreSkillEnhancement}";
+
+            var stats = new Dictionary<StatType, double>();
+            var avatarInfo = _assets.GetAvatarInfo(agentId.ToString());
+
+            if (avatarInfo == null || avatarInfo.BaseProps == null)
+                return stats;
+
+            foreach (var prop in avatarInfo.BaseProps)
+            {
+                if (int.TryParse(prop.Key, out int propertyId) && Enum.IsDefined(typeof(StatType), propertyId))
+                {
+                    StatType statType = (StatType)propertyId;
+
+                    string propCacheKey = $"{cacheKey}_{propertyId}";
+
+                    if (_calculationCache.TryGetValue(propCacheKey, out double cachedValue))
+                    {
+                        stats[statType] = cachedValue;
+                        continue;
+                    }
+
+                    double baseValueRaw = prop.Value;
+                    double growthValueRaw = 0;
+                    double promotionValueRaw = 0;
+                    double coreEnhancementValueRaw = 0;
+
+                    if (avatarInfo.GrowthProps != null && avatarInfo.GrowthProps.TryGetValue(prop.Key, out int growthValueInt))
+                    {
+                        growthValueRaw = (growthValueInt * (level - 1)) / 10000.0;
+                    }
+
+                    if (avatarInfo.PromotionProps != null && promotionLevel > 0 && promotionLevel <= avatarInfo.PromotionProps.Count)
+                    {
+                        var promotionProps = avatarInfo.PromotionProps[promotionLevel - 1];
+                        if (promotionProps.TryGetValue(prop.Key, out int promoValueInt))
+                        {
+                            promotionValueRaw = promoValueInt;
+                        }
+                    }
+
+                    if (avatarInfo.CoreEnhancementProps != null && coreSkillEnhancement >= 0 &&
+                        coreSkillEnhancement < avatarInfo.CoreEnhancementProps.Count)
+                    {
+                        var coreProps = avatarInfo.CoreEnhancementProps[coreSkillEnhancement];
+                        if (coreProps.TryGetValue(prop.Key, out int coreValueInt))
+                        {
+                            coreEnhancementValueRaw = coreValueInt;
+                        }
+                    }
+
+                    double totalRawContribution = baseValueRaw + growthValueRaw + promotionValueRaw + coreEnhancementValueRaw;
+
+                    // Cache the result
+                    _calculationCache[propCacheKey] = totalRawContribution;
+
+                    stats[statType] = totalRawContribution;
+                }
+            }
+            return stats;
+        }
+
+        public (ZZZStat MainStat, ZZZStat SecondaryStat) CalculateWeaponStats(int weaponId, int level, int breakLevel)
+        {
+            string cacheKey = $"weapon_{weaponId}_{level}_{breakLevel}";
+
+            if (_calculationCache.TryGetValue(cacheKey + "_main", out double cachedMainValue) &&
+                _calculationCache.TryGetValue(cacheKey + "_secondary", out double cachedSecondaryValue) &&
+                _calculationCache.TryGetValue(cacheKey + "_mainId", out double cachedMainId) &&
+                _calculationCache.TryGetValue(cacheKey + "_secondaryId", out double cachedSecondaryId))
+            {
+                var mainStatz = CreateStatWithProperScaling((int)cachedMainId, cachedMainValue);
+                var secondaryStatz = CreateStatWithProperScaling((int)cachedSecondaryId, cachedSecondaryValue);
+                return (mainStatz, secondaryStatz);
+            }
+
+            var weaponInfo = _assets.GetWeaponInfo(weaponId.ToString());
+
+            if (weaponInfo?.MainStat == null || weaponInfo?.SecondaryStat == null)
+                return (new ZZZStat { Type = StatType.None }, new ZZZStat { Type = StatType.None });
+
+            int mainStatPropId = weaponInfo.MainStat.PropertyId;
+            double mainStatBaseAtL1 = weaponInfo.MainStat.PropertyValue;
+            double mainStatValue = mainStatBaseAtL1 * GetWeaponLevelMultiplier(weaponId, level, breakLevel);
+
+            int secondaryStatPropId = weaponInfo.SecondaryStat.PropertyId;
+            double secondaryStatBaseAtL1 = weaponInfo.SecondaryStat.PropertyValue;
+            double secondaryStatValue = secondaryStatBaseAtL1 * GetWeaponAscensionMultiplier(weaponId, breakLevel);
+
+            _calculationCache[cacheKey + "_main"] = mainStatValue;
+            _calculationCache[cacheKey + "_secondary"] = secondaryStatValue;
+            _calculationCache[cacheKey + "_mainId"] = mainStatPropId;
+            _calculationCache[cacheKey + "_secondaryId"] = secondaryStatPropId;
+
+            var mainStat = CreateStatWithProperScaling(mainStatPropId, mainStatValue);
+            var secondaryStat = CreateStatWithProperScaling(secondaryStatPropId, secondaryStatValue);
+
+            return (mainStat, secondaryStat);
+        }
+
+        private double GetWeaponLevelMultiplier(int weaponId, int level, int breakLevel)
+        {
+            string cacheKey = $"weapon_level_mult_{weaponId}_{level}_{breakLevel}";
+
+            if (_calculationCache.TryGetValue(cacheKey, out double cachedValue))
+                return cachedValue;
+
+            double result = (1.0 + 0.1568166666666667 * level + 0.8922 * breakLevel);
+            _calculationCache[cacheKey] = result;
+            return result;
+        }
+
+        private double GetWeaponAscensionMultiplier(int weaponId, int breakLevel)
+        {
+            string cacheKey = $"weapon_asc_mult_{weaponId}_{breakLevel}";
+
+            if (_calculationCache.TryGetValue(cacheKey, out double cachedValue))
+                return cachedValue;
+
+            double result = (1.0 + 0.3 * breakLevel);
+            _calculationCache[cacheKey] = result;
+            return result;
+        }
+
+        public ZZZStat CalculateDriveDiscMainStat(int propertyId, double baseValue, int discLevel, int propertyLevel, Rarity rarity)
+        {
+            string cacheKey = $"disc_main_{propertyId}_{baseValue}_{discLevel}_{propertyLevel}_{rarity}";
+
+            if (_calculationCache.TryGetValue(cacheKey, out double cachedValue))
+                return CreateStatWithProperScaling(propertyId, cachedValue, propertyLevel);
+
+            double rarityScale = GetRarityScale(rarity);
+            double calculatedValue = baseValue + (baseValue * discLevel * rarityScale);
+
+            _calculationCache[cacheKey] = calculatedValue;
+
+            return CreateStatWithProperScaling(propertyId, calculatedValue, propertyLevel);
+        }
+
+        private double GetRarityScale(Rarity rarity)
+        {
+            string cacheKey = $"rarity_scale_{rarity}";
+
+            if (_calculationCache.TryGetValue(cacheKey, out double cachedValue))
+                return cachedValue;
+
+            double scale = rarity switch
+            {
+                Rarity.S => 0.2,
+                Rarity.A => 0.25,
+                Rarity.B => 0.3,
+                _ => 0.2
+            };
+
+            _calculationCache[cacheKey] = scale;
+            return scale;
+        }
+
+        public ZZZStat CreateStatWithProperScaling(int propertyId, double rawValue, int level = 0)
+        {
+            if (!Enum.IsDefined(typeof(StatType), propertyId))
+            {
+                return new ZZZStat { Type = StatType.None, Value = rawValue, Level = level };
+            }
+
+            StatType statType = (StatType)propertyId;
+            double calculationValue = rawValue;
+            bool isPercentage = ZZZStatsHelpers.IsDisplayPercentageStat(statType);
+
+            if (ZZZStatsHelpers.IsCalculationPercentageStat(statType) &&
+                statType != StatType.CritRateBase &&
+                statType != StatType.CritDMGBase &&
+                statType != StatType.EnergyRegenBase)
+            {
+                calculationValue = rawValue / 100;
+            }
+
+            return new ZZZStat
+            {
+                Type = statType,
+                Value = calculationValue,
+                FormattedValue = (calculationValue * level),
+                Level = level,
+                IsPercentage = isPercentage
+            };
+        }
+
+        public void ClearCache()
+        {
+            _calculationCache.Clear();
+        }
+    }
+}

--- a/EnkaDotNet/Utils/ZZZ/ZZZStatsHelpers.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZStatsHelpers.cs
@@ -1,0 +1,744 @@
+﻿using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Enums.ZZZ;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EnkaDotNet.Utils.ZZZ
+{
+    public static class ZZZStatsHelpers
+    {
+        private const double BASE_CRIT_RATE = 0.05;  // 5%
+        private const double BASE_CRIT_DMG = 0.50;   // 50%
+        private const double BASE_ENERGY_REGEN = 0;
+        private static readonly IZZZAssets assets = new ZZZAssets();
+
+        public static Dictionary<string, double> CalculateAllTotalStats(ZZZAgent agent)
+        {
+            var breakdown = CalculateTotalBreakdown(agent, assets);
+
+            return breakdown.ToDictionary(
+                kv => kv.Key,
+                kv => kv.Value.TryGetValue("Final", out var total) ? total : 0
+            );
+        }
+
+        public static bool IsDisplayPercentageStatForGroup(string statGroup)
+        {
+            switch (statGroup)
+            {
+                case "Crit Rate":
+                case "Crit DMG":
+                case "Pen Ratio":
+                case "Physical DMG":
+                case "Fire DMG":
+                case "Ice DMG":
+                case "Electric DMG":
+                case "Ether DMG":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsDisplayPercentageStat(StatType statType)
+        {
+            string category = GetStatCategoryDisplay(statType);
+            switch (category)
+            {
+                case "Crit Rate":
+                case "Crit DMG":
+                case "Pen Ratio":
+                case "Physical DMG":
+                case "Fire DMG":
+                case "Ice DMG":
+                case "Electric DMG":
+                case "Ether DMG":
+                case "HP%":
+                case "ATK%":
+                case "Def%":
+                case "Impact%":
+                    return true;
+                case "Energy Regen":
+                case "HP":
+                case "ATK":
+                case "Def":
+                case "Impact":
+                case "Anomaly Mastery":
+                case "Anomaly Proficiency":
+                case "PEN":
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsCalculationPercentageStat(StatType statType)
+        {
+            return statType switch
+            {
+                StatType.HPPercent => true,
+                StatType.ATKPercent => true,
+                StatType.DefPercent => true,
+                StatType.ImpactPercent => true,
+                StatType.EnergyRegenPercent => true,
+                StatType.AnomalyMasteryPercent => true,
+
+                StatType.CritRateBase => true,
+                StatType.CritRateFlat => true,
+                StatType.CritDMGBase => true,
+                StatType.CritDMGFlat => true,
+
+                StatType.EnergyRegenBase => true,
+                StatType.EnergyRegenFlat => true,
+
+                StatType.PenRatioBase => true,
+                StatType.PenRatioFlat => true,
+
+                StatType.PhysicalDMGBonusBase => true,
+                StatType.PhysicalDMGBonusFlat => true,
+                StatType.FireDMGBonusBase => true,
+                StatType.FireDMGBonusFlat => true,
+                StatType.IceDMGBonusBase => true,
+                StatType.IceDMGBonusFlat => true,
+                StatType.ElectricDMGBonusBase => true,
+                StatType.ElectricDMGBonusFlat => true,
+                StatType.EtherDMGBonusBase => true,
+                StatType.EtherDMGBonusFlat => true,
+
+                _ => false
+            };
+        }
+
+        private static Dictionary<string, Dictionary<string, double>> CalculateTotalBreakdown(ZZZAgent agent, IZZZAssets assets)
+        {
+            var breakdown = InitializeTotalsDictionary();
+
+            foreach (var stat in agent.Stats)
+            {
+                AddContribution(breakdown, stat.Key, stat.Value, "Agent");
+            }
+
+            if (agent.Weapon != null)
+            {
+                if (agent.Weapon.MainStat.Type == StatType.ATKBase)
+                {
+                    breakdown["ATK"]["WeaponBase"] += agent.Weapon.MainStat.Value;
+                }
+
+                if (agent.Weapon.SecondaryStat.Type == StatType.CritRateFlat)
+                {
+                    double value = agent.Weapon.SecondaryStat.Value;
+                    if (value > 1.0)
+                        value /= 100.0;
+                    breakdown["Crit Rate"]["Weapon_Flat"] += value;
+                }
+                else if (agent.Weapon.SecondaryStat.Type == StatType.CritDMGFlat)
+                {
+                    double value = agent.Weapon.SecondaryStat.Value;
+                    if (value > 1.0)
+                        value /= 100.0;
+                    breakdown["Crit DMG"]["Weapon_Flat"] += value;
+                }
+                else if (agent.Weapon.SecondaryStat.Type == StatType.EnergyRegenPercent)
+                {
+                    double value = agent.Weapon.SecondaryStat.Value;
+                    breakdown["Energy Regen"]["Weapon_Percent"] += value;
+                }
+                else
+                {
+                    AddContribution(breakdown, agent.Weapon.SecondaryStat.Type, agent.Weapon.SecondaryStat.Value, "Weapon");
+                }
+            }
+
+            foreach (var disc in agent.EquippedDiscs)
+            {
+                if (disc.MainStat.Type == StatType.CritRateFlat)
+                {
+                    double value = disc.MainStat.Value;
+                    if (value > 1.0)
+                        value /= 100.0;
+
+                    breakdown["Crit Rate"]["Discs_Flat"] += value;
+                }
+                else if (disc.MainStat.Type == StatType.CritDMGFlat)
+                {
+                    double value = disc.MainStat.Value;
+                    if (value > 1.0)
+                        value /= 100.0;
+
+                    breakdown["Crit DMG"]["Discs_Flat"] += value;
+                }
+                else
+                {
+                    AddContribution(breakdown, disc.MainStat.Type, disc.MainStat.Value, "Discs");
+                }
+
+                foreach (var subStat in disc.SubStats)
+                {
+                    if (subStat.Type == StatType.CritRateFlat)
+                    {
+                        double baseValue = subStat.Value;
+                        if (baseValue > 1.0)
+                            baseValue /= 100.0;
+
+                        double scaledValue = baseValue * subStat.Level;
+                        breakdown["Crit Rate"]["Discs_Flat"] += scaledValue;
+                    }
+                    else if (subStat.Type == StatType.CritDMGFlat)
+                    {
+                        double baseValue = subStat.Value;
+                        if (baseValue > 1.0)
+                            baseValue /= 100.0;
+
+                        double scaledValue = baseValue * subStat.Level;
+                        breakdown["Crit DMG"]["Discs_Flat"] += scaledValue;
+                    }
+                    else
+                    {
+                        double originalValue = subStat.Value;
+                        double scaledValue = originalValue * subStat.Level;
+                        AddContribution(breakdown, subStat.Type, scaledValue, "Discs");
+                    }
+                }
+            }
+
+            ApplySetBonuses(agent, breakdown, assets);
+
+            CalculateFinalValues(breakdown);
+
+            return breakdown;
+        }
+        private static Dictionary<string, Dictionary<string, double>> InitializeTotalsDictionary()
+        {
+            var breakdown = new Dictionary<string, Dictionary<string, double>>();
+            var statGroups = new List<string> {
+                "HP", "ATK", "Def", "Impact", "Crit Rate", "Crit DMG", "Energy Regen",
+                "Anomaly Mastery", "Anomaly Proficiency", "Pen Ratio", "PEN",
+                "Physical DMG", "Fire DMG", "Ice DMG", "Electric DMG", "Ether DMG"
+            };
+
+            foreach (var group in statGroups)
+            {
+                breakdown[group] = new Dictionary<string, double> {
+                    { "Agent_Base", 0 }, { "Agent_Flat", 0 }, { "Agent_Percent", 0 },
+                    { "WeaponBase", 0 },
+                    { "Weapon_Flat", 0 }, { "Weapon_Percent", 0 },
+                    { "Discs_Flat", 0 }, { "Discs_Percent", 0 },
+                    { "SetBonus_Flat", 0 }, { "SetBonus_Percent", 0 },
+                    { "Final", 0 }
+                };
+            }
+
+            breakdown["Crit Rate"]["Agent_Base"] = BASE_CRIT_RATE;
+            breakdown["Crit DMG"]["Agent_Base"] = BASE_CRIT_DMG;
+            breakdown["Energy Regen"]["Agent_Base"] = BASE_ENERGY_REGEN;
+
+            return breakdown;
+        }
+
+        private static void AddContribution(Dictionary<string, Dictionary<string, double>> breakdown, StatType statType, double value, string sourcePrefix)
+        {
+            string category = GetStatCategory(statType);
+            if (string.IsNullOrEmpty(category) || !breakdown.ContainsKey(category)) return;
+
+            string targetBucketSuffix;
+            double valueToAdd = value;
+
+            if (category == "Crit Rate" || category == "Crit DMG")
+            {
+                if (sourcePrefix == "Agent" && statType.ToString().EndsWith("Base"))
+                {
+                    targetBucketSuffix = "Base";
+                    valueToAdd = (category == "Crit Rate") ? BASE_CRIT_RATE : BASE_CRIT_DMG;
+                }
+                else if (sourcePrefix != "Agent")
+                {
+                    targetBucketSuffix = "Flat";
+
+                    if (value > 1.0)
+                    {
+                        valueToAdd = value / 100.0;
+                    }
+                }
+                else
+                {
+                    targetBucketSuffix = "Flat";
+                }
+            }
+            else
+            {
+                bool isPercentForCalc = IsCalculationPercentageStat(statType);
+                bool isAgentBase = sourcePrefix == "Agent" && statType.ToString().EndsWith("Base");
+
+                if (sourcePrefix == "Agent")
+                {
+                    if (isAgentBase)
+                    {
+                        if (statType == StatType.EnergyRegenBase)
+                        {
+                            valueToAdd = value / 100;
+                        }
+                        targetBucketSuffix = "Base";
+                    }
+                    else if (isPercentForCalc)
+                    {
+                        valueToAdd = value / 100.0;
+                        targetBucketSuffix = "Percent";
+                    }
+                    else
+                    {
+                        targetBucketSuffix = "Flat";
+                    }
+                }
+                else
+                {
+                    if (isPercentForCalc)
+                    {
+                        if (sourcePrefix == "SetBonus")
+                        {
+                            valueToAdd = value / 100.0;
+                        }
+
+                        if (statType == StatType.EnergyRegenFlat || statType == StatType.PenRatioFlat ||
+                            statType.ToString().Contains("DMGBonusFlat"))
+                        {
+                            targetBucketSuffix = "Flat";
+                        }
+                        else
+                        {
+                            targetBucketSuffix = "Percent";
+                        }
+                    }
+                    else
+                    {
+                        targetBucketSuffix = "Flat";
+                    }
+                }
+            }
+
+            string bucketKey = $"{sourcePrefix}_{targetBucketSuffix}";
+
+            if (targetBucketSuffix == "Base" && sourcePrefix != "Agent")
+            {
+                bucketKey = sourcePrefix + targetBucketSuffix;
+            }
+
+            if (!breakdown[category].ContainsKey(bucketKey))
+            {
+                breakdown[category][bucketKey] = 0;
+            }
+
+            breakdown[category][bucketKey] += valueToAdd;
+        }
+
+        private static void ApplySetBonuses(ZZZAgent agent, Dictionary<string, Dictionary<string, double>> breakdown, IZZZAssets assets)
+        {
+            var equippedSets = agent.EquippedDiscs
+                .GroupBy(d => d.SuitId)
+                .Where(g => g.Count() >= 2)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            foreach (var set in equippedSets)
+            {
+                int suitId = set.Key;
+                int pieceCount = set.Value;
+                var suitInfo = assets.GetDiscSetInfo(suitId.ToString());
+
+                if (suitInfo?.SetBonusProps == null || !suitInfo.SetBonusProps.Any()) continue;
+
+                var applicableBonusProps = suitInfo.SetBonusProps;
+
+                foreach (var prop in applicableBonusProps)
+                {
+                    if (int.TryParse(prop.Key, out int propertyId) && Enum.IsDefined(typeof(StatType), propertyId))
+                    {
+                        StatType statType = (StatType)propertyId;
+                        double rawValue = prop.Value;
+                        string category = GetStatCategory(statType);
+
+                        if (statType == StatType.EnergyRegenPercent)
+                        {
+                            rawValue = rawValue / 1000.0;
+                            breakdown["Energy Regen"]["SetBonus_Percent"] += rawValue;
+                        }
+                        else if (category == "Crit Rate" || category == "Crit DMG")
+                        {
+                            rawValue = rawValue / 1000.0;
+                            breakdown[category]["SetBonus_Flat"] += rawValue;
+                        }
+                        else if (IsCalculationPercentageStat(statType))
+                        {
+                            rawValue = rawValue / 1000.0;
+                            breakdown[category]["SetBonus_Percent"] += rawValue;
+                        }
+                        else
+                        {
+                            breakdown[category]["SetBonus_Flat"] += rawValue;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void CalculateFinalValues(Dictionary<string, Dictionary<string, double>> breakdown)
+        {
+            foreach (var category in breakdown.Keys)
+            {
+                var catBreakdown = breakdown[category];
+
+                double totalPercentBonus = (catBreakdown["Agent_Percent"] + catBreakdown["Weapon_Percent"] +
+                                 catBreakdown["Discs_Percent"] + catBreakdown["SetBonus_Percent"]) / 100.0;
+
+                double totalFlatBonus = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                      catBreakdown["Discs_Flat"];
+
+                double agentBase = catBreakdown["Agent_Base"];
+                double weaponBase = catBreakdown.ContainsKey("WeaponBase") ? catBreakdown["WeaponBase"] : 0;
+
+                double finalValue = 0;
+
+                double bonusFlat = catBreakdown["SetBonus_Flat"] / 10;
+
+                switch (category)
+                {
+                    case "HP":
+                        double flooredHPBase = Math.Floor(agentBase);
+                        double percentBonus = flooredHPBase * totalPercentBonus;
+                        finalValue = flooredHPBase + Math.Round(percentBonus) + totalFlatBonus;
+                        catBreakdown["BaseDisplay"] = flooredHPBase;
+                        catBreakdown["AddedDisplay"] = finalValue - flooredHPBase;
+                        break;
+                    case "ATK":
+                        double flooredAgentATK = Math.Floor(agentBase);
+                        double flooredWeaponATK = Math.Floor(weaponBase);
+                        double combinedBaseATK = flooredAgentATK + flooredWeaponATK;
+                        double discPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double weaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double agentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double setBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+                        double atkDiscPercentBonus = combinedBaseATK * discPercentBonus;
+                        double atkSetBonusValue = combinedBaseATK * setBonusPercent;
+                        double atkAgentWeaponPercentBonus = combinedBaseATK * (agentPercentBonus + weaponPercentBonus);
+                        double flatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                           catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+                        double addedValue = Math.Floor(atkDiscPercentBonus) + Math.Round(atkSetBonusValue) + Math.Floor(atkAgentWeaponPercentBonus) + flatBonuses;
+                        finalValue = combinedBaseATK + addedValue;
+                        catBreakdown["BaseDisplay"] = combinedBaseATK;
+                        catBreakdown["AddedDisplay"] = addedValue;
+                        break;
+
+                    case "Def":
+                        double flooredDefBase = Math.Floor(agentBase);
+
+                        double defDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double defWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double defAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double defSetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+
+                        double defDiscValue = flooredDefBase * defDiscPercentBonus;
+                        double defSetValue = flooredDefBase * defSetBonusPercent;
+                        double defAgentWeaponValue = flooredDefBase * (defAgentPercentBonus + defWeaponPercentBonus);
+
+                        double defFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                              catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double defAddedValue = Math.Floor(defDiscValue) + Math.Round(defSetValue) +
+                                             Math.Floor(defAgentWeaponValue) + defFlatBonuses;
+
+                        finalValue = flooredDefBase + defAddedValue;
+                        catBreakdown["BaseDisplay"] = flooredDefBase;
+                        catBreakdown["AddedDisplay"] = defAddedValue;
+                        break;
+
+                    case "Impact":
+                        double flooredImpactBase = Math.Floor(agentBase);
+
+                        double impactDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double impactWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double impactAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double impactSetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+
+                        double impactDiscValue = flooredImpactBase * impactDiscPercentBonus;
+                        double impactSetValue = flooredImpactBase * impactSetBonusPercent;
+                        double impactAgentWeaponValue = flooredImpactBase * (impactAgentPercentBonus + impactWeaponPercentBonus);
+
+                        double impactFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                                 catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double impactAddedValue = Math.Floor(impactDiscValue) + Math.Round(impactSetValue) +
+                                               Math.Round(impactAgentWeaponValue) + impactFlatBonuses;
+
+                        finalValue = flooredImpactBase + impactAddedValue;
+                        catBreakdown["BaseDisplay"] = flooredImpactBase;
+                        catBreakdown["AddedDisplay"] = impactAddedValue;
+                        break;
+
+                    case "Anomaly Mastery":
+                        double flooredAnomalyMasteryBase = Math.Floor(agentBase);
+
+                        double anomalyMasteryDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double anomalyMasteryWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double anomalyMasteryAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double anomalyMasterySetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+
+                        double anomalyMasteryDiscValue = flooredAnomalyMasteryBase * anomalyMasteryDiscPercentBonus;
+                        double anomalyMasterySetValue = flooredAnomalyMasteryBase * anomalyMasterySetBonusPercent;
+                        double anomalyMasteryAgentWeaponValue = flooredAnomalyMasteryBase * (anomalyMasteryAgentPercentBonus + anomalyMasteryWeaponPercentBonus);
+
+                        double anomalyMasteryFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                                         catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double anomalyMasteryAddedValue = Math.Floor(anomalyMasteryDiscValue) + Math.Round(anomalyMasterySetValue) +
+                                                       Math.Floor(anomalyMasteryAgentWeaponValue) + anomalyMasteryFlatBonuses;
+
+                        finalValue = flooredAnomalyMasteryBase + anomalyMasteryAddedValue;
+                        catBreakdown["BaseDisplay"] = flooredAnomalyMasteryBase;
+                        catBreakdown["AddedDisplay"] = anomalyMasteryAddedValue;
+                        break;
+
+                    case "Anomaly Proficiency":
+                        double flooredAnomalyProficiencyBase = Math.Floor(agentBase);
+
+                        double anomalyProficiencyDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double anomalyProficiencyWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double anomalyProficiencyAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double anomalyProficiencySetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+
+                        double anomalyProficiencyDiscValue = flooredAnomalyProficiencyBase * anomalyProficiencyDiscPercentBonus;
+                        double anomalyProficiencySetValue = flooredAnomalyProficiencyBase * anomalyProficiencySetBonusPercent;
+                        double anomalyProficiencyAgentWeaponValue = flooredAnomalyProficiencyBase * (anomalyProficiencyAgentPercentBonus + anomalyProficiencyWeaponPercentBonus);
+
+                        double anomalyProficiencyFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                                             catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double anomalyProficiencyAddedValue = Math.Floor(anomalyProficiencyDiscValue) + Math.Round(anomalyProficiencySetValue) +
+                                                           Math.Floor(anomalyProficiencyAgentWeaponValue) + anomalyProficiencyFlatBonuses;
+
+                        finalValue = flooredAnomalyProficiencyBase + anomalyProficiencyAddedValue;
+                        catBreakdown["BaseDisplay"] = flooredAnomalyProficiencyBase;
+                        catBreakdown["AddedDisplay"] = anomalyProficiencyAddedValue;
+                        break;
+
+                    case "PEN":
+                        double flooredPENBase = Math.Floor(agentBase);
+
+                        double penDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double penWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double penAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double penSetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] / 10.0) : 0;
+
+                        double penDiscValue = flooredPENBase * penDiscPercentBonus;
+                        double penSetValue = flooredPENBase * penSetBonusPercent;
+                        double penAgentWeaponValue = flooredPENBase * (penAgentPercentBonus + penWeaponPercentBonus);
+
+                        double penFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                              catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double penAddedValue = Math.Floor(penDiscValue) + Math.Round(penSetValue) +
+                                             Math.Floor(penAgentWeaponValue) + penFlatBonuses;
+
+                        finalValue = flooredPENBase + penAddedValue;
+                        catBreakdown["BaseDisplay"] = flooredPENBase;
+                        catBreakdown["AddedDisplay"] = penAddedValue;
+                        break;
+
+                    case "Crit Rate":
+                        finalValue = (BASE_CRIT_RATE + totalFlatBonus + totalPercentBonus + bonusFlat) * 100;
+                        catBreakdown["BaseDisplay"] = (BASE_CRIT_RATE * 100);
+                        catBreakdown["AddedDisplay"] = totalFlatBonus + totalPercentBonus + bonusFlat;
+                        break;
+
+                    case "Crit DMG":
+                        finalValue = (BASE_CRIT_DMG + totalFlatBonus + totalPercentBonus + bonusFlat) * 100;
+                        catBreakdown["BaseDisplay"] = (BASE_CRIT_DMG * 100);
+                        catBreakdown["AddedDisplay"] = totalFlatBonus + totalPercentBonus + bonusFlat;
+                        break;
+
+                    case "Energy Regen":
+                        double weaponRegenBonus = catBreakdown["Weapon_Percent"];
+                        double discRegenBonus = catBreakdown["Discs_Percent"];
+                        double setBonusRegenBonus = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] - 0.91) : 0;
+
+                        finalValue = agentBase + totalFlatBonus + discRegenBonus + setBonusRegenBonus;
+                        catBreakdown["BaseDisplay"] = agentBase;
+                        catBreakdown["AddedDisplay"] = totalFlatBonus + weaponRegenBonus + discRegenBonus + setBonusRegenBonus;
+                        break;
+                    case "Pen Ratio":
+                    case "Physical DMG":
+                    case "Fire DMG":
+                    case "Ice DMG":
+                    case "Electric DMG":
+                    case "Ether DMG":
+                        double elemDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
+                        double elemWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
+                        double elemAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
+                        double elemSetBonusPercent = catBreakdown["SetBonus_Percent"] != 0 ? (catBreakdown["SetBonus_Percent"] * 10.0) : 0;
+
+                        double elemDiscValue = elemDiscPercentBonus;
+                        double elemSetValue = elemSetBonusPercent;
+                        double elemAgentWeaponValue = elemAgentPercentBonus + elemWeaponPercentBonus;
+
+                        double elemFlatBonuses = catBreakdown["Agent_Flat"] + catBreakdown["Weapon_Flat"] +
+                                               catBreakdown["Discs_Flat"] + catBreakdown["SetBonus_Flat"];
+
+                        double elemTotalValue = elemDiscValue + elemSetValue + elemAgentWeaponValue + elemFlatBonuses;
+
+                        finalValue = elemTotalValue;
+                        catBreakdown["BaseDisplay"] = 0;
+                        catBreakdown["AddedDisplay"] = finalValue;
+                        break;
+                    default:
+                        finalValue = agentBase * (1.0 + totalPercentBonus) + totalFlatBonus;
+                        catBreakdown["BaseDisplay"] = agentBase;
+                        catBreakdown["AddedDisplay"] = finalValue - agentBase;
+                        break;
+                }
+
+                catBreakdown["Final"] = finalValue;
+            }
+        }
+
+        public static string GetStatCategory(StatType statType)
+        {
+            switch (statType)
+            {
+                case StatType.HPBase: case StatType.HPPercent: case StatType.HPFlat: return "HP";
+                case StatType.ATKBase: case StatType.ATKPercent: case StatType.ATKFlat: return "ATK";
+                case StatType.DefBase: case StatType.DefPercent: case StatType.DefFlat: return "Def";
+                case StatType.ImpactBase: case StatType.ImpactPercent: return "Impact";
+
+                case StatType.CritRateBase: case StatType.CritRateFlat: return "Crit Rate";
+                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "Crit DMG";
+
+                case StatType.EnergyRegenBase: case StatType.EnergyRegenPercent: case StatType.EnergyRegenFlat: return "Energy Regen";
+
+                case StatType.AnomalyMasteryBase: case StatType.AnomalyMasteryPercent: case StatType.AnomalyMasteryFlat: return "Anomaly Mastery";
+                case StatType.AnomalyProficiencyBase: case StatType.AnomalyProficiencyFlat: return "Anomaly Proficiency";
+
+                case StatType.PenRatioBase: case StatType.PenRatioFlat: return "Pen Ratio";
+                case StatType.PENBase: case StatType.PENFlat: return "PEN";
+
+                case StatType.PhysicalDMGBonusBase: case StatType.PhysicalDMGBonusFlat: return "Physical DMG";
+                case StatType.FireDMGBonusBase: case StatType.FireDMGBonusFlat: return "Fire DMG";
+                case StatType.IceDMGBonusBase: case StatType.IceDMGBonusFlat: return "Ice DMG";
+                case StatType.ElectricDMGBonusBase: case StatType.ElectricDMGBonusFlat: return "Electric DMG";
+                case StatType.EtherDMGBonusBase: case StatType.EtherDMGBonusFlat: return "Ether DMG";
+
+                default: return "";
+            }
+        }
+
+        public static string GetStatCategoryDisplay(StatType statType)
+        {
+            switch (statType)
+            {
+                case StatType.HPBase: case StatType.HPFlat: return "HP";
+                case StatType.ATKBase: case StatType.ATKFlat: return "ATK";
+                case StatType.DefBase: case StatType.DefFlat: return "Def";
+                case StatType.ImpactBase: return "Impact";
+
+                case StatType.HPPercent: return "HP%";
+                case StatType.ATKPercent: return "ATK%";
+                case StatType.DefPercent: return "Def%";
+                case StatType.ImpactPercent: return "Impact%";
+
+                case StatType.CritRateBase: case StatType.CritRateFlat: return "Crit Rate";
+                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "Crit DMG";
+
+                case StatType.EnergyRegenBase: case StatType.EnergyRegenPercent: case StatType.EnergyRegenFlat: return "Energy Regen";
+
+                case StatType.AnomalyMasteryBase: case StatType.AnomalyMasteryPercent: case StatType.AnomalyMasteryFlat: return "Anomaly Mastery";
+                case StatType.AnomalyProficiencyBase: case StatType.AnomalyProficiencyFlat: return "Anomaly Proficiency";
+
+                case StatType.PenRatioBase: case StatType.PenRatioFlat: return "Pen Ratio";
+                case StatType.PENBase: case StatType.PENFlat: return "PEN";
+
+                case StatType.PhysicalDMGBonusBase: case StatType.PhysicalDMGBonusFlat: return "Physical DMG";
+                case StatType.FireDMGBonusBase: case StatType.FireDMGBonusFlat: return "Fire DMG";
+                case StatType.IceDMGBonusBase: case StatType.IceDMGBonusFlat: return "Ice DMG";
+                case StatType.ElectricDMGBonusBase: case StatType.ElectricDMGBonusFlat: return "Electric DMG";
+                case StatType.EtherDMGBonusBase: case StatType.EtherDMGBonusFlat: return "Ether DMG";
+
+                default: return "";
+            }
+        }
+
+        public static StatBreakdown GetStatSourceBreakdown(ZZZAgent agent, string statGroup)
+        {
+            var breakdownData = CalculateTotalBreakdown(agent, assets);
+            if (!breakdownData.TryGetValue(statGroup, out var catBreakdown))
+            {
+                return new StatBreakdown { StatGroup = statGroup };
+            }
+
+            var result = new StatBreakdown
+            {
+                StatGroup = statGroup,
+                IsPercentage = IsDisplayPercentageStatForGroup(statGroup)
+            };
+
+            result.TotalValue = catBreakdown["Final"];
+
+            if (statGroup == "Crit Rate")
+            {
+                result.BaseValue = (BASE_CRIT_RATE * 100);
+            }
+            else if (statGroup == "Crit DMG")
+            {
+                result.BaseValue = (BASE_CRIT_DMG * 100);
+            }
+            else
+            {
+                result.BaseValue = catBreakdown["Agent_Base"];
+                if (statGroup == "ATK") result.BaseValue += catBreakdown["WeaponBase"];
+                if (statGroup == "Energy Regen") result.BaseValue = catBreakdown["Agent_Base"];
+                if (statGroup.Contains("DMG") || statGroup == "Pen Ratio") result.BaseValue = 0;
+            }
+
+            result.WeaponValue = catBreakdown["Weapon_Flat"] + catBreakdown["Weapon_Percent"];
+            result.DiscsValue = catBreakdown["Discs_Flat"] + catBreakdown["Discs_Percent"];
+            result.SetBonusValue = catBreakdown["SetBonus_Flat"] + catBreakdown["SetBonus_Percent"];
+
+            if (result.TotalValue != 0)
+            {
+                double addedValue = result.TotalValue - result.BaseValue;
+                if (addedValue != 0)
+                {
+                    result.WeaponContributionPercent = result.WeaponValue / addedValue;
+                    result.DiscsContributionPercent = result.DiscsValue / addedValue;
+                    result.SetBonusContributionPercent = result.SetBonusValue / addedValue;
+                }
+                result.BaseContributionPercent = result.BaseValue / result.TotalValue;
+            }
+
+            return result;
+        }
+    }
+
+    public class StatBreakdown
+    {
+        public string StatGroup { get; set; } = string.Empty;
+        public bool IsPercentage { get; set; }
+
+        public double BaseValue { get; set; }
+        public double WeaponValue { get; set; }
+        public double DiscsValue { get; set; }
+        public double SetBonusValue { get; set; }
+        public double TotalValue { get; set; }
+
+        public double BaseContributionPercent { get; set; }
+        public double WeaponContributionPercent { get; set; }
+        public double DiscsContributionPercent { get; set; }
+        public double SetBonusContributionPercent { get; set; }
+
+        public ZZZStatValue Base => new ZZZStatValue(BaseValue, IsPercentage);
+        public ZZZStatValue Weapon => new ZZZStatValue(WeaponValue, IsPercentage);
+        public ZZZStatValue Discs => new ZZZStatValue(DiscsValue, IsPercentage);
+        public ZZZStatValue SetBonus => new ZZZStatValue(SetBonusValue, IsPercentage);
+        public ZZZStatValue Total => new ZZZStatValue(TotalValue, IsPercentage);
+
+        public double AddedValue => TotalValue - BaseValue;
+        public ZZZStatValue Added => new ZZZStatValue(AddedValue, IsPercentage);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Enka.DotNet is a wrapper for accessing and processing character data from the En
 | ----------------- | -------------- | ----------- |
 | Genshin Impact    | ✅ Ready       | Full        |
 | Honkai: Star Rail | ⏳ Coming Soon | Planned     |
-| Zenless Zone Zero | ⏳ Coming Soon | Planned     |
+| Zenless Zone Zero | ✅ Ready       | Full        |
 
 ## Installation
 
@@ -161,9 +161,151 @@ catch (Exception ex) when (
 }
 ```
 
+## Example Code for Zenless Zone Zero
+
+```csharp
+using EnkaDotNet;
+using EnkaDotNet.Enums;
+
+namespace ZZZStatsViewer
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            try
+            {
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+                var options = new EnkaClientOptions
+                {
+                    GameType = GameType.ZZZ,
+                    Language = "ja"
+                };
+
+                using var client = new EnkaClient(options);
+
+                int uid = args.Length > 0 && int.TryParse(args[0], out int parsedUid) ? parsedUid : 1302375046;
+
+                Console.WriteLine($"Fetching player data for UID: {uid}...");
+                var playerInfo = await client.GetZZZPlayerInfo(uid);
+
+                Console.WriteLine($"Player: {playerInfo.Nickname} (Lv.{playerInfo.Level})");
+                Console.WriteLine($"Title: {playerInfo.TitleText}");
+                Console.WriteLine($"Signature: {playerInfo.Signature}");
+                Console.WriteLine($"Player Icon: {playerInfo.ProfilePictureIcon}");
+                Console.WriteLine($"Player Namecard Icon: {playerInfo.NameCardIcon}");
+
+                if (playerInfo.ShowcaseAgents.Count == 0)
+                {
+                    Console.WriteLine("\nNo showcase agents found.");
+                    return;
+                }
+
+                // Display medals
+                Console.WriteLine("\nMEDALS:");
+                foreach (var medal in playerInfo.Medals)
+                {
+                    Console.WriteLine($"Name: {medal.Name} (Lv.{medal.Value})");
+                    Console.WriteLine($"Icon: {medal.Icon}");
+                    Console.WriteLine($"Type: {medal.Type}");
+                }
+
+                // Display agent info
+                var agent = playerInfo.ShowcaseAgents[2];
+                Console.WriteLine($"\nAGENT: {agent.Name} (Lv.{agent.Level})");
+                Console.WriteLine($"Rarity: {agent.Rarity} | Profession: {agent.ProfessionType}");
+                Console.WriteLine($"Elements: {string.Join(", ", agent.ElementTypes)}");
+
+                // Display Mindscapes
+                Console.WriteLine($"Mindscapes: M{agent.TalentLevel}");
+
+                // Display agent's image URL
+                Console.WriteLine($"Image URL: {agent.ImageUrl}");
+                Console.WriteLine($"Circle Icon URL: {agent.CircleIconUrl}");
+                Console.WriteLine($"Promotion Level: {agent.PromotionLevel}");
+
+                var stats = agent.GetAllStats();
+                foreach (var stat in stats)
+                {
+                    Console.WriteLine($"{stat.Key}: {stat.Value}");
+                }
+
+                // Display weapon
+                if (agent.Weapon != null)
+                {
+                    Console.WriteLine("\nW-ENGINE:");
+                    Console.WriteLine($"Name: {agent.Weapon.Name} (Lv.{agent.Weapon.Level}/{agent.Weapon.BreakLevel})");
+                    Console.WriteLine($"Rarity: {agent.Weapon.Rarity}");
+                    Console.WriteLine($"Main Stat: {agent.Weapon.MainStat}");
+                    Console.WriteLine($"Secondary Stat: {agent.Weapon.SecondaryStat}");
+                    Console.WriteLine($"Effect State: {agent.WeaponEffectState}");
+                    Console.WriteLine($"Enhancements: {string.Join(", ", agent.CoreSkillEnhancements)}");
+                    Console.WriteLine($"Enhancement Level: {agent.CoreSkillEnhancement}");
+                    Console.WriteLine($"Overclock: {agent.Weapon.UpgradeLevel}");
+                    Console.WriteLine($"Icon URL: {agent.Weapon.ImageUrl}");
+                }
+
+                // Display equipped disc sets
+                var discSets = agent.GetEquippedDiscSets();
+                if (discSets.Count > 0)
+                {
+                    Console.WriteLine("\nDRIVE DISC SETS:");
+                    foreach (var set in discSets)
+                    {
+                        Console.WriteLine($"- {set.SuitName} ({set.PieceCount} pieces)");
+                        foreach (var disc in set.BonusStats)
+                        {
+                            Console.WriteLine($"  - {disc.StatType}: {disc.Value}");
+                        }
+                    }
+                }
+
+                // Display equipped discs
+                if (agent.EquippedDiscs.Count > 0)
+                {
+                    Console.WriteLine("\nEQUIPPED DISCS:");
+                    foreach (var disc in agent.EquippedDiscs)
+                    {
+                        Console.WriteLine($"- {disc.SuitName} (Lv.{disc.Level})");
+                        Console.WriteLine($"  - Main Stats: {disc.MainStat}");
+                        Console.WriteLine($"  - Rarity: {disc.Rarity}");
+                        Console.WriteLine($"  - Slot: {disc.Slot}");
+                        Console.WriteLine($"  - Icon URL: {disc.IconUrl}");
+                        Console.WriteLine($"  - Locked: {disc.IsLocked}");
+                        Console.WriteLine($"  - Available: {disc.IsAvailable}");
+                        Console.WriteLine($"  - Trash: {disc.IsTrash}");
+
+                        foreach (var stat in disc.SubStats)
+                        {
+                            if (stat.IsPercentage)
+                            {
+                                Console.WriteLine($"  - {stat.Type}: {stat.Value * stat.Level:F1}% +{stat.Level}");
+                            }
+                            else
+                            {
+                                Console.WriteLine($"  - {stat.Type}: {(int)stat.Value * stat.Level} +{stat.Level}");
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+            }
+        }
+    }
+}
+```
+
 ## Requirements
 
 - .NET 8.0 or higher
+
+## Support
+
+Having questions or issues? Join our Discord server: [Alg's Dev Env](https://discord.gg/d4UgxagmwF)
 
 ## License
 


### PR DESCRIPTION
This commit introduces support for the game "Zenless Zone Zero" (ZZZ) in the EnkaDotNet library. Key changes include the addition of new asset classes and interfaces for ZZZ, updates to the AssetsFactory and EnkaClient for ZZZ data retrieval, and enhancements to the Constants class with default API URLs for ZZZ. The GameType enum has been updated to include ZZZ, and the README.md has been modified to provide example code for fetching ZZZ player data. New utility classes for calculating ZZZ stats have also been added, along with mapping for ZZZ player and agent information. The project version has been updated to reflect these changes.