### PR TITLE
Add Options property for flexible stat formatting

### DIFF
--- a/EnkaDotNet/Components/Genshin/Artifact.cs
+++ b/EnkaDotNet/Components/Genshin/Artifact.cs
@@ -1,4 +1,5 @@
 ﻿using EnkaDotNet.Enums.Genshin;
+using EnkaDotNet.Utils.Genshin;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,9 +12,25 @@ namespace EnkaDotNet.Components.Genshin
 {
     public class Artifact : EquipmentBase
     {
+        internal EnkaClientOptions Options { get; set; }
         public string SetName { get; internal set; } = string.Empty;
         public ArtifactSlot Slot { get; internal set; }
         public StatProperty MainStat { get; internal set; }
         public List<StatProperty> SubStats { get; internal set; } = new List<StatProperty>();
+
+        public KeyValuePair<string, string> FormattedMainStat =>
+             MainStat != null ? FormatStat(MainStat.Type, MainStat.Value)
+             : new KeyValuePair<string, string>(Options?.Raw ?? false ? "None" : "None", "0");
+
+        public List<KeyValuePair<string, string>> FormattedSubStats =>
+            SubStats?.Select(s => FormatStat(s.Type, s.Value)).ToList() ?? new List<KeyValuePair<string, string>>();
+
+        private KeyValuePair<string, string> FormatStat(StatType type, double value)
+        {
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? type.ToString() : GenshinStatUtils.GetDisplayName(type);
+            string formattedValue = GenshinStatUtils.FormatValue(type, value, raw);
+            return new KeyValuePair<string, string>(key, formattedValue);
+        }
     }
 }

--- a/EnkaDotNet/Components/Genshin/Character.cs
+++ b/EnkaDotNet/Components/Genshin/Character.cs
@@ -6,11 +6,13 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EnkaDotNet.Enums.Genshin;
+using EnkaDotNet.Utils.Genshin;
 
 namespace EnkaDotNet.Components.Genshin
 {
     public class Character
     {
+        internal EnkaClientOptions Options { get; set; }
         public int Id { get; internal set; }
         public string Name { get; internal set; } = string.Empty;
         public int Level { get; internal set; }
@@ -27,102 +29,18 @@ namespace EnkaDotNet.Components.Genshin
         public int CostumeId { get; internal set; }
         public string IconUrl { get; internal set; } = string.Empty;
 
-        public double GetStatValue(StatType statType, out string value)
+
+        public Dictionary<string, string> GetAllStats()
         {
-            if (Stats.TryGetValue(statType, out double RawValue))
+            bool raw = this.Options?.Raw ?? false;
+            var formatted = new Dictionary<string, string>();
+            foreach (var kvp in Stats)
             {
-                bool isPercent = statType.ToString().Contains("Bonus") ||
-                                 statType == StatType.CriticalRate ||
-                                 statType == StatType.CriticalDamage ||
-                                 statType == StatType.EnergyRecharge ||
-                                 statType.ToString().Contains("Percentage");
-
-                if (isPercent)
-                {
-                    double percentValue = statType.ToString().Contains("Percentage") ? RawValue : RawValue * 100;
-                    value = $"{percentValue:F1}";
-                }
-                else
-                {
-                    value = $"{Math.Floor(RawValue)}";
-                }
-                return RawValue;
+                string key = raw ? kvp.Key.ToString() : GenshinStatUtils.GetDisplayName(kvp.Key);
+                string value = GenshinStatUtils.FormatValueStats(kvp.Key, kvp.Value, raw);
+                formatted.Add(key, value);
             }
-            else
-            {
-                value = "0";
-                return 0.0;
-            }
-        }
-
-        public Dictionary<string, Dictionary<StatType, (double Raw, string Formatted)>> GetStats()
-        {
-            var result = new Dictionary<string, Dictionary<StatType, (double Raw, string Formatted)>>();
-
-            result["Base Stats"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Percentage Stats"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Critical Stats"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Energy & Mastery"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Healing"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Resistances"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Damage Bonuses"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Final Stats"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-            result["Other"] = new Dictionary<StatType, (double Raw, string Formatted)>();
-
-            foreach (var statPair in Stats)
-            {
-                StatType type = statPair.Key;
-                double rawValue = statPair.Value;
-                GetStatValue(type, out string formattedValue); // Use the updated GetStatValue
-
-                if (type == StatType.BaseHP || type == StatType.BaseAttack ||
-                    type == StatType.BaseDefense || type == StatType.BaseSpeed)
-                {
-                    result["Base Stats"][type] = (rawValue, formattedValue);
-                }
-                else if (type == StatType.HPPercentage || type == StatType.AttackPercentage ||
-                         type == StatType.DefensePercentage || type == StatType.SpeedPercentage)
-                {
-                    result["Percentage Stats"][type] = (rawValue, formattedValue);
-                }
-                else if (type == StatType.CriticalRate || type == StatType.CriticalDamage)
-                {
-                    result["Critical Stats"][type] = (rawValue, formattedValue);
-                }
-                else if (type == StatType.EnergyRecharge || type == StatType.ElementalMastery)
-                {
-                    result["Energy & Mastery"][type] = (rawValue, formattedValue);
-                }
-                else if (type == StatType.HealingBonus || type == StatType.IncomingHealingBonus)
-                {
-                    result["Healing"][type] = (rawValue, formattedValue);
-                }
-                else if (type.ToString().Contains("Resistance"))
-                {
-                    result["Resistances"][type] = (rawValue, formattedValue);
-                }
-                else if (type.ToString().Contains("DamageBonus"))
-                {
-                    result["Damage Bonuses"][type] = (rawValue, formattedValue);
-                }
-                else if (type == StatType.HP || type == StatType.Attack ||
-                         type == StatType.Defense || type == StatType.Speed)
-                {
-                    result["Final Stats"][type] = (rawValue, formattedValue);
-                }
-                else
-                {
-                    result["Other"][type] = (rawValue, formattedValue);
-                }
-            }
-
-            var emptyCategories = result.Where(kvp => kvp.Value.Count == 0).Select(kvp => kvp.Key).ToList();
-            foreach (var category in emptyCategories)
-            {
-                result.Remove(category);
-            }
-
-            return result;
+            return formatted;
         }
     }
 }

--- a/EnkaDotNet/Components/Genshin/Constellation.cs
+++ b/EnkaDotNet/Components/Genshin/Constellation.cs
@@ -10,9 +10,16 @@ namespace EnkaDotNet.Components.Genshin
 {
     public class Constellation
     {
+        internal EnkaClientOptions Options { get; set; }
         public int Id { get; internal set; }
         public string Name { get; internal set; } = string.Empty;
         public string IconUrl { get; internal set; } = string.Empty;
         public int Position { get; internal set; }
+
+        public override string ToString()
+        {
+            bool raw = Options?.Raw ?? false;
+            return raw ? Id.ToString() : $"{Name} (C{Position})";
+        }
     }
 }

--- a/EnkaDotNet/Components/Genshin/StatProperty.cs
+++ b/EnkaDotNet/Components/Genshin/StatProperty.cs
@@ -1,4 +1,5 @@
 ﻿using EnkaDotNet.Enums.Genshin;
+using EnkaDotNet.Utils.Genshin;
 using System.Globalization;
 using System;
 using System.Collections.Generic;
@@ -12,33 +13,19 @@ namespace EnkaDotNet.Components.Genshin
 {
     public class StatProperty
     {
+        internal EnkaClientOptions Options { get; set; }
         public StatType Type { get; internal set; }
-
         public double Value { get; internal set; }
 
         public override string ToString()
         {
-            bool isPercent = Type.ToString().Contains("Percentage") ||
-                             Type.ToString().Contains("Bonus") ||
-                             Type == StatType.CriticalRate ||
-                             Type == StatType.CriticalDamage ||
-                             Type == StatType.EnergyRecharge;
-
-            string valueString;
-            if (isPercent)
-            {
-                valueString = (Value * 100).ToString("F1", CultureInfo.InvariantCulture) + "%";
-            }
-            else if (Value == (int)Value)
-            {
-                valueString = Value.ToString("N0", CultureInfo.InvariantCulture);
-            }
-            else
-            {
-                valueString = Value.ToString("F1", CultureInfo.InvariantCulture);
-            }
-
-            return $"{Type}: {valueString}";
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? Type.ToString() : GenshinStatUtils.GetDisplayName(Type);
+            string value = GenshinStatUtils.FormatValueStats(Type, Value, raw);
+            return $"{key}: {value}";
         }
+
+        public string FormattedValue => GenshinStatUtils.FormatValueStats(Type, Value, Options?.Raw ?? false);
+        public string DisplayName => GenshinStatUtils.GetDisplayName(Type);
     }
 }

--- a/EnkaDotNet/Components/Genshin/Talent.cs
+++ b/EnkaDotNet/Components/Genshin/Talent.cs
@@ -10,11 +10,21 @@ namespace EnkaDotNet.Components.Genshin
 {
     public class Talent
     {
+        internal EnkaClientOptions Options { get; set; }
         public int Id { get; internal set; }
         public string Name { get; internal set; } = string.Empty;
         public int Level { get; internal set; }
         public int BaseLevel { get; internal set; }
         public int ExtraLevel { get; internal set; }
         public string IconUrl { get; internal set; } = string.Empty;
+
+        public override string ToString()
+        {
+            bool raw = Options?.Raw ?? false;
+            if (raw) return Id.ToString();
+
+            string levelInfo = ExtraLevel > 0 ? $"{BaseLevel}+{ExtraLevel}={Level}" : $"{Level}";
+            return $"{Name} Lv.{levelInfo}";
+        }
     }
 }

--- a/EnkaDotNet/Components/Genshin/Weapon.cs
+++ b/EnkaDotNet/Components/Genshin/Weapon.cs
@@ -5,17 +5,33 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-
 using EnkaDotNet.Enums.Genshin;
+using EnkaDotNet.Utils.Genshin;
 
 namespace EnkaDotNet.Components.Genshin
 {
     public class Weapon : EquipmentBase
     {
+        internal EnkaClientOptions Options { get; set; }
         public WeaponType Type { get; internal set; }
         public int Ascension { get; internal set; }
         public int Refinement { get; internal set; }
         public double BaseAttack { get; internal set; }
         public StatProperty SecondaryStat { get; internal set; }
+
+        public KeyValuePair<string, string> FormattedBaseAttack =>
+            FormatStat(StatType.BaseAttack, BaseAttack);
+
+        public KeyValuePair<string, string> FormattedSecondaryStat =>
+            SecondaryStat != null ? FormatStat(SecondaryStat.Type, SecondaryStat.Value)
+            : new KeyValuePair<string, string>(Options?.Raw ?? false ? "None" : "None", "0");
+
+        private KeyValuePair<string, string> FormatStat(StatType type, double value)
+        {
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? type.ToString() : GenshinStatUtils.GetDisplayName(type);
+            string formattedValue = GenshinStatUtils.FormatValue(type, value, raw);
+            return new KeyValuePair<string, string>(key, formattedValue);
+        }
     }
 }

--- a/EnkaDotNet/Components/HSR/HSRLightCone.cs
+++ b/EnkaDotNet/Components/HSR/HSRLightCone.cs
@@ -6,11 +6,15 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EnkaDotNet.Enums.HSR;
+using System.Globalization;
+using EnkaDotNet.Utils.HSR;
 
 namespace EnkaDotNet.Components.HSR
 {
     public class HSRLightCone
     {
+        internal EnkaClientOptions Options { get; set; }
+
         public int Id { get; internal set; }
         public string Name { get; internal set; } = string.Empty;
         public int Level { get; internal set; }
@@ -29,6 +33,19 @@ namespace EnkaDotNet.Components.HSR
         public override string ToString()
         {
             return $"{Name} (Lv.{Level}/{Promotion}, Rank {Rank})";
+        }
+
+        public KeyValuePair<string, string> FormattedBaseHP => GetFormattedStat("BaseHP", BaseHP);
+        public KeyValuePair<string, string> FormattedBaseAttack => GetFormattedStat("BaseAttack", BaseAttack);
+        public KeyValuePair<string, string> FormattedBaseDefense => GetFormattedStat("BaseDefence", BaseDefense);
+
+
+        private KeyValuePair<string, string> GetFormattedStat(string propertyType, double value)
+        {
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? propertyType : HSRStatPropertyUtils.GetDisplayName(propertyType);
+            string formattedValue = raw ? value.ToString(CultureInfo.InvariantCulture) : Math.Floor(value).ToString();
+            return new KeyValuePair<string, string>(key, formattedValue);
         }
     }
 }

--- a/EnkaDotNet/Components/HSR/HSRRelic.cs
+++ b/EnkaDotNet/Components/HSR/HSRRelic.cs
@@ -6,11 +6,15 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EnkaDotNet.Enums.HSR;
+using EnkaDotNet.Utils.HSR;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.HSR
 {
     public class HSRRelic
     {
+        internal EnkaClientOptions Options { get; set; }
+
         public int Id { get; internal set; }
         public int Level { get; internal set; }
         public int Type { get; internal set; }
@@ -27,6 +31,18 @@ namespace EnkaDotNet.Components.HSR
         public override string ToString()
         {
             return $"{SetName} {RelicType} (Lv.{Level})";
+        }
+
+        public KeyValuePair<string, string> FormattedMainStat => GetAllStats(MainStat);
+
+        public List<KeyValuePair<string, string>> FormattedSubStats => SubStats.Select(GetAllStats).ToList();
+
+        private KeyValuePair<string, string> GetAllStats(HSRStatProperty stat)
+        {
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? stat.Type : HSRStatPropertyUtils.GetDisplayName(stat.Type);
+            string value = raw ? stat.Value.ToString(CultureInfo.InvariantCulture) : stat.DisplayValue;
+            return new KeyValuePair<string, string>(key, value);
         }
     }
 }

--- a/EnkaDotNet/Components/HSR/HSRStats.cs
+++ b/EnkaDotNet/Components/HSR/HSRStats.cs
@@ -8,11 +8,14 @@ using System.Threading.Tasks;
 using EnkaDotNet.Components.HSR.EnkaDotNet.Enums.HSR;
 using EnkaDotNet.Enums.HSR;
 using EnkaDotNet.Utils.HSR;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.HSR
 {
     public class HSRStatProperty
     {
+        internal EnkaClientOptions Options { get; set; }
+
         public string Type { get; set; } = string.Empty;
         public StatPropertyType PropertyType { get; set; }
         public double Value { get; set; }
@@ -23,6 +26,9 @@ namespace EnkaDotNet.Components.HSR
         {
             get
             {
+                bool raw = Options?.Raw ?? false;
+                if (raw) return Value.ToString(CultureInfo.InvariantCulture);
+
                 if (IsPercentage)
                 {
                     return $"{Value * 100:F1}%";
@@ -48,37 +54,52 @@ namespace EnkaDotNet.Components.HSR
 
         public override string ToString()
         {
-            return $"{HSRStatPropertyUtils.GetDisplayName(Type)}: {DisplayValue}";
+            bool raw = Options?.Raw ?? false;
+            string key = raw ? Type : HSRStatPropertyUtils.GetDisplayName(Type);
+            return $"{key}: {DisplayValue}";
         }
     }
 
     public class HSRStatValue
     {
+        internal EnkaClientOptions Options { get; set; }
+
         public double Raw { get; set; }
-        public double FormattedValue { get; set; }
+
         public string Formatted { get; set; }
         public bool IsPercentage { get; set; }
 
-        public HSRStatValue(double raw, bool isPercentage = false, int decimalPlaces = 0)
+        public HSRStatValue(double raw, EnkaClientOptions options = null, bool isPercentage = false, int decimalPlaces = 0)
         {
+            Options = options;
             Raw = raw;
-            FormattedValue = raw;
-            IsPercentage = isPercentage;
 
-            if (isPercentage)
+            IsPercentage = isPercentage;
+            bool useRawFormatting = Options?.Raw ?? false;
+
+            if(useRawFormatting)
             {
+
+                 Formatted = raw.ToString(CultureInfo.InvariantCulture);
+            }
+            else if (isPercentage)
+            {
+
                 Formatted = $"{raw:F1}%";
             }
             else if (decimalPlaces > 0)
             {
+
                 string format = $"F{decimalPlaces}";
-                Formatted = $"{raw.ToString(format)}";
+                Formatted = $"{raw.ToString(format, CultureInfo.InvariantCulture)}";
             }
             else
             {
+
                 Formatted = $"{(int)raw}";
             }
         }
+
 
         public override string ToString() => Formatted;
     }
@@ -100,6 +121,8 @@ namespace EnkaDotNet.Components.HSR
 
     public class HSRSkillTree
     {
+        internal EnkaClientOptions Options { get; set; }
+
         public int PointId { get; set; }
         public int Level { get; set; }
         public int BaseLevel { get; set; }
@@ -114,6 +137,9 @@ namespace EnkaDotNet.Components.HSR
 
         public override string ToString()
         {
+            bool raw = Options?.Raw ?? false;
+            if(raw) return $"{PointId} - {Level}";
+
             string levelInfo = IsBoosted ? $"{BaseLevel}+{Level - BaseLevel}={Level}" : $"{Level}";
             return $"{Name} ({TraceType}) - Lv.{levelInfo}/{MaxLevel}";
         }

--- a/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
@@ -7,6 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnkaDotNet.Enums.ZZZ;
 using EnkaDotNet.Utils.ZZZ;
+using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Assets.ZZZ.Models;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.ZZZ
 {
@@ -38,45 +41,108 @@ namespace EnkaDotNet.Components.ZZZ
 
         public Dictionary<StatType, double> Stats { get; internal set; } = new Dictionary<StatType, double>();
 
-        private Dictionary<string, ZZZStatValue> _cachedTotalStats;
+        internal EnkaClientOptions Options { get; set; }
+        internal IZZZAssets Assets { get; set; }
 
-        public Dictionary<string, ZZZStatValue> GetAllStats()
+        public Dictionary<string, string> GetAllStats()
         {
-            if (_cachedTotalStats != null)
-                return _cachedTotalStats;
+            bool raw = this.Options?.Raw ?? false;
+            var resultStats = new Dictionary<string, string>();
+            var calculatedStats = ZZZStatsHelpers.CalculateAllTotalStats(this);
 
-            _cachedTotalStats = new Dictionary<string, ZZZStatValue>();
-            var rawTotals = ZZZStatsHelpers.CalculateAllTotalStats(this);
-
-            foreach (var stat in rawTotals)
+            foreach (var statPair in calculatedStats)
             {
-                bool isPercentage = ZZZStatsHelpers.IsDisplayPercentageStatForGroup(stat.Key);
-                bool isEnergyRegen = stat.Key == "Energy Regen";
+                string friendlyKey = statPair.Key;
+                double numericValue = statPair.Value;
+                bool isPercentage = ZZZStatsHelpers.IsDisplayPercentageStatForGroup(friendlyKey);
+                bool isEnergyRegen = friendlyKey == "Energy Regen";
+                StatType statType = ZZZStatsHelpers.GetStatTypeFromFriendlyName(friendlyKey, isPercentage, isEnergyRegen);
 
-                _cachedTotalStats[stat.Key] = new ZZZStatValue(
-                    stat.Value,
-                    isPercentage,
-                    isEnergyRegen
-                );
+                string displayKey;
+                string displayValue;
+
+                if (raw)
+                {
+                    displayKey = statType.ToString();
+                    if (isEnergyRegen) displayValue = numericValue.ToString("F2", CultureInfo.InvariantCulture);
+                    else if (isPercentage) displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture);
+                    else displayValue = Math.Floor(numericValue).ToString();
+                }
+                else
+                {
+                    displayKey = friendlyKey;
+                    if (isEnergyRegen) displayValue = numericValue.ToString("F2", CultureInfo.InvariantCulture);
+                    else if (isPercentage) displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    else displayValue = Math.Floor(numericValue).ToString();
+                }
+                resultStats[displayKey] = displayValue;
             }
-
-            return _cachedTotalStats;
+            return resultStats;
         }
 
-        public ZZZStatValue GetStat(string statName)
+        public List<FormattedDriveDiscSetInfo> GetEquippedDiscSets()
         {
-            var stats = GetAllStats();
-            return stats.TryGetValue(statName, out var stat) ? stat : new ZZZStatValue(0);
-        }
+            var result = new List<FormattedDriveDiscSetInfo>();
+            bool raw = this.Options?.Raw ?? false;
 
-        public List<DriveDiscSetInfo> GetEquippedDiscSets()
-        {
-            return ZZZDriveDiscSetHelper.GetEquippedDiscSets(this);
-        }
+            if (Assets == null) return result;
+            if (EquippedDiscs.Count < 2) return result;
 
-        public StatBreakdown GetStatBreakdown(string statName)
-        {
-            return ZZZStatsHelpers.GetStatSourceBreakdown(this, statName);
+            var discSetsGrouped = EquippedDiscs
+                .GroupBy(d => d.SuitId)
+                .Where(g => g.Count() >= 2)
+                .Select(g => new { SuitId = g.Key, Count = g.Count(), Discs = g.ToList() })
+                .ToList();
+
+            foreach (var set in discSetsGrouped)
+            {
+                var firstDisc = set.Discs.First();
+                var suitInfo = Assets.GetDiscSetInfo(set.SuitId.ToString());
+
+                var setInfo = new FormattedDriveDiscSetInfo
+                {
+                    SuitName = firstDisc.SuitName,
+                    PieceCount = set.Count,
+                };
+
+                if (suitInfo?.SetBonusProps != null && suitInfo.SetBonusProps.Any())
+                {
+                    setInfo.BonusStats = suitInfo.SetBonusProps
+                        .Where(prop => int.TryParse(prop.Key, out int propId) && Enum.IsDefined(typeof(StatType), propId))
+                        .Select(prop =>
+                        {
+                            var statType = (StatType)int.Parse(prop.Key);
+                            string key;
+                            string value;
+                            double numericValue = prop.Value;
+
+                            if (raw)
+                            {
+                                key = statType.ToString();
+                                if (statType == StatType.EnergyRegenPercent) value = Math.Floor(numericValue).ToString();
+                                else if (ZZZStatsHelpers.IsCalculationPercentageStat(statType)) value = (numericValue).ToString("F1", CultureInfo.InvariantCulture);
+                                else value = Math.Floor(numericValue).ToString();
+                            }
+                            else
+                            {
+                                key = ZZZStatsHelpers.GetStatCategoryDisplay(statType);
+                                if (statType == StatType.EnergyRegenPercent) value = $"{(numericValue / 100.0):F1}%";
+                                else if (ZZZStatsHelpers.IsDisplayPercentageStat(statType)) value = $"{(numericValue / 100.0):F1}%";
+                                else value = $"{Math.Floor(numericValue)}";
+                            }
+                            return new KeyValuePair<string, string>(key, value);
+                        }).ToList();
+                }
+                result.Add(setInfo);
+            }
+            return result;
         }
+    }
+
+    public class FormattedDriveDiscSetInfo
+    {
+        public string SuitName { get; set; } = string.Empty;
+        public int PieceCount { get; set; }
+        public List<KeyValuePair<string, string>> BonusStats { get; set; } = new List<KeyValuePair<string, string>>();
     }
 }

--- a/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using EnkaDotNet.Enums.ZZZ;
+using EnkaDotNet.Utils.ZZZ;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.ZZZ
 {
@@ -26,6 +28,40 @@ namespace EnkaDotNet.Components.ZZZ
         public string IconUrl { get; internal set; } = string.Empty;
 
         public ZZZStat MainStat { get; internal set; } = new ZZZStat();
-        public List<ZZZStat> SubStats { get; internal set; } = new List<ZZZStat>();
+        public List<ZZZStat> SubStatsRaw { get; internal set; } = new List<ZZZStat>();
+
+        internal EnkaClientOptions Options { get; set; }
+
+        public KeyValuePair<string, string> FormattedMainStat
+        {
+            get
+            {
+                bool raw = Options?.Raw ?? false;
+                string key = raw ? MainStat.Type.ToString() : ZZZStatsHelpers.GetStatCategoryDisplay(MainStat.Type);
+                string value;
+                if (MainStat.IsPercentage && !raw) value = (MainStat.Value).ToString("F1", CultureInfo.InvariantCulture) + "%";
+                else value = Math.Floor(MainStat.Value).ToString();
+                return new KeyValuePair<string, string>(key, value);
+            }
+        }
+
+        public List<KeyValuePair<string, string>> SubStats
+        {
+            get
+            {
+                bool raw = Options?.Raw ?? false;
+                var formattedList = new List<KeyValuePair<string, string>>();
+                foreach (var stat in SubStatsRaw)
+                {
+                    string key = raw ? stat.Type.ToString() : ZZZStatsHelpers.GetStatCategoryDisplay(stat.Type);
+                    double totalValue = stat.Value * stat.Level;
+                    string value;
+                    if (stat.IsPercentage && !raw) value = (totalValue).ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    else value = Math.Floor(totalValue).ToString();
+                    formattedList.Add(new KeyValuePair<string, string>(key, $"{value} +{stat.Level}"));
+                }
+                return formattedList;
+            }
+        }
     }
 }

--- a/EnkaDotNet/Components/ZZZ/ZZZStat.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZStat.cs
@@ -6,22 +6,16 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using EnkaDotNet.Utils.ZZZ;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.ZZZ
 {
     public class ZZZStat
     {
-        public StatType Type { get; set; }
+        public StatType Type { get; set; } = StatType.None;
         public double Value { get; set; }
-        public double FormattedValue { get; set; }
         public int Level { get; set; }
         public bool IsPercentage { get; internal set; }
-
-        public string DisplayValue => IsPercentage ? $"{Value:F1}%" : $"{(int)Value}";
-
-        public override string ToString()
-        {
-            return $"{Type}: {DisplayValue}";
-        }
     }
 }

--- a/EnkaDotNet/Components/ZZZ/ZZZStatValue.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZStatValue.cs
@@ -5,14 +5,18 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using EnkaDotNet.Utils.ZZZ;
+using EnkaDotNet.Enums.ZZZ;
+using System.Globalization;
+
 namespace EnkaDotNet.Components.ZZZ
 {
     public class ZZZStatValue
     {
         public double Raw { get; set; }
-        public string Formatted { get; set; }
-        public bool IsPercentage { get; set; }
-        public bool IsEnergyRegen { get; set; }
+        public string Formatted { get; private set; }
+        public bool IsPercentage { get; private set; }
+        public bool IsEnergyRegen { get; private set; }
 
         public ZZZStatValue(double raw, bool isPercentage = false, bool isEnergyRegen = false)
         {
@@ -20,18 +24,9 @@ namespace EnkaDotNet.Components.ZZZ
             IsPercentage = isPercentage;
             IsEnergyRegen = isEnergyRegen;
 
-            if (isEnergyRegen)
-            {
-                Formatted = $"{raw:F2}";
-            }
-            else if (isPercentage)
-            {
-                Formatted = $"{raw:F1}%";
-            }
-            else
-            {
-                Formatted = $"{Math.Floor(raw)}";
-            }
+            if (isEnergyRegen) Formatted = $"{raw:F2}";
+            else if (isPercentage) Formatted = $"{raw:F1}%";
+            else Formatted = $"{Math.Floor(raw)}";
         }
 
         public override string ToString() => Formatted;

--- a/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using EnkaDotNet.Utils.ZZZ;
+using System.Globalization;
 
 namespace EnkaDotNet.Components.ZZZ
 {
@@ -26,5 +28,42 @@ namespace EnkaDotNet.Components.ZZZ
 
         public ZZZStat MainStat { get; internal set; } = new ZZZStat();
         public ZZZStat SecondaryStat { get; internal set; } = new ZZZStat();
+
+        internal EnkaClientOptions Options { get; set; }
+
+        public KeyValuePair<string, string> FormattedMainStat
+        {
+            get
+            {
+                bool raw = Options?.Raw ?? false;
+                string key = raw ? MainStat.Type.ToString() : ZZZStatsHelpers.GetStatCategoryDisplay(MainStat.Type);
+                string value = Math.Floor(MainStat.Value).ToString();
+                return new KeyValuePair<string, string>(key, value);
+            }
+        }
+
+        public KeyValuePair<string, string> FormattedSecondaryStat
+        {
+            get
+            {
+                bool raw = Options?.Raw ?? false;
+                string key = raw ? SecondaryStat.Type.ToString() : ZZZStatsHelpers.GetStatCategoryDisplay(SecondaryStat.Type);
+                string value;
+
+                if (raw)
+                {
+                    if (SecondaryStat.Type == StatType.EnergyRegenPercent) value = Math.Floor(SecondaryStat.Value).ToString();
+                    else if (SecondaryStat.IsPercentage) value = SecondaryStat.Value.ToString("F1", CultureInfo.InvariantCulture);
+                    else value = Math.Floor(SecondaryStat.Value).ToString();
+                }
+                else
+                {
+                    if (SecondaryStat.Type == StatType.EnergyRegenPercent) value = (SecondaryStat.Value / 100.0).ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    else if (SecondaryStat.IsPercentage) value = SecondaryStat.Value.ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    else value = Math.Floor(SecondaryStat.Value).ToString();
+                }
+                return new KeyValuePair<string, string>(key, value);
+            }
+        }
     }
 }

--- a/EnkaDotNet/EnkaClientOptions.cs
+++ b/EnkaDotNet/EnkaClientOptions.cs
@@ -12,26 +12,17 @@ namespace EnkaDotNet
     public class EnkaClientOptions
     {
         public string UserAgent { get; set; }
-
         public string BaseUrl { get; set; }
-
         public string AssetBaseUrl { get; set; }
-
         public int TimeoutSeconds { get; set; } = 30;
-
         public bool EnableCaching { get; set; } = true;
-
         public int CacheDurationMinutes { get; set; } = 5;
-
         public int MaxRetries { get; set; } = 0;
-
         public int RetryDelayMs { get; set; } = 1000;
-
         public bool EnableVerboseLogging { get; set; } = false;
-
         public string Language { get; set; } = "en";
-
         public GameType GameType { get; set; } = GameType.Genshin;
+        public bool Raw { get; set; } = false;
 
         public EnkaClientOptions() { }
 
@@ -49,7 +40,8 @@ namespace EnkaDotNet
                 RetryDelayMs = this.RetryDelayMs,
                 EnableVerboseLogging = this.EnableVerboseLogging,
                 Language = this.Language,
-                GameType = this.GameType
+                GameType = this.GameType,
+                Raw = this.Raw
             };
         }
     }

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 	<LangVersion>7.3</LangVersion>
        <ImplicitUsings>false</ImplicitUsings>
        <OutputType>Library</OutputType>
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.3.0</Version>
+       <Version>1.3.1</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/EnkaDotNet/Utils/Genshin/DataMapper.cs
+++ b/EnkaDotNet/Utils/Genshin/DataMapper.cs
@@ -15,10 +15,12 @@ namespace EnkaDotNet.Utils.Genshin
     public class DataMapper
     {
         private readonly IGenshinAssets _assets;
+        private readonly EnkaClientOptions _options;
 
-        public DataMapper(IGenshinAssets assets)
+        public DataMapper(IGenshinAssets assets, EnkaClientOptions options)
         {
             _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         public PlayerInfo MapPlayerInfo(PlayerInfoModel model)
@@ -88,6 +90,7 @@ namespace EnkaDotNet.Utils.Genshin
                 Artifacts = model.EquipList?.Select(equipModel => MapEquipment(equipModel)).OfType<Artifact>().ToList() ?? new List<Artifact>(),
                 Name = _assets.GetCharacterName(model.AvatarId),
                 IconUrl = _assets.GetCharacterIconUrl(model.AvatarId),
+                Options = this._options
             };
 
             character.ConstellationLevel = character.UnlockedConstellationIds.Count;
@@ -97,7 +100,8 @@ namespace EnkaDotNet.Utils.Genshin
                    Id = id,
                    Name = _assets.GetConstellationName(id),
                    IconUrl = _assets.GetConstellationIconUrl(id),
-                   Position = index + 1
+                   Position = index + 1,
+                   Options = this._options
                })
                .ToList();
 
@@ -145,13 +149,14 @@ namespace EnkaDotNet.Utils.Genshin
                 SecondaryStat = secondaryStat,
                 Type = weaponType,
                 Name = _assets.GetWeaponNameFromHash(flat.NameTextMapHash) ?? $"Weapon_{equip.ItemId}",
-                IconUrl = _assets.GetWeaponIconUrlFromIconName(flat.Icon)
+                IconUrl = _assets.GetWeaponIconUrlFromIconName(flat.Icon),
+                Options = this._options
             };
         }
 
         private Artifact MapArtifact(EquipModel equip, ReliquaryModel reliquary, FlatDataModel flat)
         {
-            var mainStat = MapStatProperty(flat.ReliquaryMainstat) ?? new StatProperty { Type = StatType.None, Value = 0 };
+            var mainStat = MapStatProperty(flat.ReliquaryMainstat) ?? new StatProperty { Type = StatType.None, Value = 0, Options = this._options };
             var subStats = flat.ReliquarySubstats?
                              .Select(substatModel => MapStatProperty(substatModel))
                              .Where(s => s != null)
@@ -167,7 +172,8 @@ namespace EnkaDotNet.Utils.Genshin
                 SubStats = subStats,
                 SetName = _assets.GetArtifactSetNameFromHash(flat.SetNameTextMapHash) ?? "Unknown Set",
                 Name = _assets.GetArtifactNameFromHash(flat.NameTextMapHash) ?? $"Artifact_{equip.ItemId}",
-                IconUrl = _assets.GetArtifactIconUrlFromIconName(flat.Icon)
+                IconUrl = _assets.GetArtifactIconUrlFromIconName(flat.Icon),
+                Options = this._options
             };
         }
 
@@ -261,7 +267,8 @@ namespace EnkaDotNet.Utils.Genshin
                     ExtraLevel = extraLevel,
                     Level = baseLevel + extraLevel,
                     Name = _assets.GetTalentName(skillId),
-                    IconUrl = _assets.GetTalentIconUrl(skillId)
+                    IconUrl = _assets.GetTalentIconUrl(skillId),
+                    Options = this._options
                 });
             }
             return talents;
@@ -278,7 +285,7 @@ namespace EnkaDotNet.Utils.Genshin
             StatType type = MapStatTypeValue(propIdString);
             if (type == StatType.None) return null;
 
-            return new StatProperty { Type = type, Value = model.StatValue };
+            return new StatProperty { Type = type, Value = model.StatValue, Options = this._options };
         }
 
         private StatType MapStatTypeKey(string key)

--- a/EnkaDotNet/Utils/Genshin/GenshinStatUtils.cs
+++ b/EnkaDotNet/Utils/Genshin/GenshinStatUtils.cs
@@ -1,0 +1,147 @@
+﻿using EnkaDotNet.Enums.Genshin;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Globalization;
+
+namespace EnkaDotNet.Utils.Genshin
+{
+    public static class GenshinStatUtils
+    {
+        private static readonly Dictionary<StatType, string> StatTypeToDisplayName = new Dictionary<StatType, string>
+        {
+            { StatType.BaseHP, "Base HP" },
+            { StatType.HP, "HP" },
+            { StatType.HPPercentage, "HP%" },
+            { StatType.BaseAttack, "Base ATK" },
+            { StatType.Attack, "ATK" },
+            { StatType.AttackPercentage, "ATK%" },
+            { StatType.BaseDefense, "Base DEF" },
+            { StatType.Defense, "DEF" },
+            { StatType.DefensePercentage, "DEF%" },
+            { StatType.BaseSpeed, "Base SPD" },
+            { StatType.Speed, "SPD" },
+            { StatType.SpeedPercentage, "SPD%" },
+            { StatType.CriticalRate, "CRIT Rate" },
+            { StatType.CriticalDamage, "CRIT DMG" },
+            { StatType.EnergyRecharge, "Energy Recharge" },
+            { StatType.ElementalMastery, "Elemental Mastery" },
+            { StatType.HealingBonus, "Healing Bonus" },
+            { StatType.IncomingHealingBonus, "Incoming Healing Bonus" },
+            { StatType.PhysicalResistance, "Physical RES" },
+            { StatType.PyroResistance, "Pyro RES" },
+            { StatType.ElectroResistance, "Electro RES" },
+            { StatType.HydroResistance, "Hydro RES" },
+            { StatType.DendroResistance, "Dendro RES" },
+            { StatType.AnemoResistance, "Anemo RES" },
+            { StatType.GeoResistance, "Geo RES" },
+            { StatType.CryoResistance, "Cryo RES" },
+            { StatType.PhysicalDamageBonus, "Physical DMG Bonus" },
+            { StatType.PyroDamageBonus, "Pyro DMG Bonus" },
+            { StatType.ElectroDamageBonus, "Electro DMG Bonus" },
+            { StatType.HydroDamageBonus, "Hydro DMG Bonus" },
+            { StatType.DendroDamageBonus, "Dendro DMG Bonus" },
+            { StatType.AnemoDamageBonus, "Anemo DMG Bonus" },
+            { StatType.GeoDamageBonus, "Geo DMG Bonus" },
+            { StatType.CryoDamageBonus, "Cryo DMG Bonus" },
+            { StatType.CooldownReduction, "CD Reduction" },
+            { StatType.ShieldStrength, "Shield Strength" },
+            { StatType.CurrentHP, "Current HP" },
+            { StatType.CurrentPyroEnergy, "Current Pyro Energy" },
+            { StatType.CurrentElectroEnergy, "Current Electro Energy" },
+            { StatType.CurrentHydroEnergy, "Current Hydro Energy" },
+            { StatType.CurrentDendroEnergy, "Current Dendro Energy" },
+            { StatType.CurrentAnemoEnergy, "Current Anemo Energy" },
+            { StatType.CurrentCryoEnergy, "Current Cryo Energy" },
+            { StatType.CurrentGeoEnergy, "Current Geo Energy" },
+            { StatType.CurrentSpecialEnergy, "Current Special Energy" }
+        };
+
+        public static string GetDisplayName(StatType statType)
+        {
+            return StatTypeToDisplayName.TryGetValue(statType, out var name) ? name : statType.ToString();
+        }
+
+        public static bool IsPercentage(StatType statType)
+        {
+            string name = statType.ToString();
+            return name.Contains("Percentage") ||
+                   name.Contains("Bonus") ||
+                   name.Contains("Resistance") ||
+                   statType == StatType.CriticalRate ||
+                   statType == StatType.CriticalDamage ||
+                   statType == StatType.EnergyRecharge ||
+                   statType == StatType.CooldownReduction ||
+                   statType == StatType.ShieldStrength;
+        }
+
+        public static string FormatValue(StatType statType, double value, bool raw)
+        {
+            if (raw)
+            {
+                return value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            bool isPercent = IsPercentage(statType);
+            if (isPercent)
+            {
+                return (value).ToString("F1", CultureInfo.InvariantCulture) + "%";
+            }
+            else
+            {
+                return Math.Round(value).ToString("N0", CultureInfo.InvariantCulture);
+            }
+        }
+
+        public static string FormatValueStats(StatType statType, double value, bool raw)
+        {
+            if (raw)
+            {
+                return value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            bool isPercent = IsPercentage(statType);
+            if (isPercent)
+            {
+                if (statType == StatType.EnergyRecharge ||
+                    statType == StatType.CooldownReduction ||
+                    statType == StatType.CriticalRate ||
+                    statType == StatType.CriticalDamage ||
+                    statType == StatType.IncomingHealingBonus)
+                {
+                    if (statType == StatType.CriticalDamage && value < 50)
+                    {
+                        value *= 100;
+                    }
+                    else if (statType == StatType.CriticalRate && value <= 5)
+                    {
+                        value *= 100;
+                    }
+                    else if (value <= 1)
+                    {
+                        value *= 100;
+                    }
+                    return (value).ToString("F1", CultureInfo.InvariantCulture) + "%";
+                }
+                else if (statType == StatType.ShieldStrength)
+                {
+                    return Math.Round(value).ToString("N0", CultureInfo.InvariantCulture) + " HP";
+                }
+                else if (statType == StatType.BaseHP || statType == StatType.HP || statType == StatType.CurrentHP)
+                {
+                    return Math.Round(value).ToString("N0", CultureInfo.InvariantCulture) + " HP";
+                }
+
+                return value.ToString("F1", CultureInfo.InvariantCulture) + "%";
+            }
+            else
+            {
+                return Math.Round(value).ToString("N0", CultureInfo.InvariantCulture);
+            }
+        }
+    }
+}

--- a/EnkaDotNet/Utils/HSR/HSRDataMapper.cs
+++ b/EnkaDotNet/Utils/HSR/HSRDataMapper.cs
@@ -12,6 +12,7 @@ using EnkaDotNet.Utils.HSR;
 using EnkaDotNet.Enums.HSR;
 using EnkaDotNet.Components.HSR.EnkaDotNet.Enums.HSR;
 using EnkaDotNet.Enums;
+using System.Globalization;
 
 namespace EnkaDotNet.Utils.HSR
 {
@@ -19,11 +20,13 @@ namespace EnkaDotNet.Utils.HSR
     {
         private readonly IHSRAssets _assets;
         private readonly HSRStatCalculator _statCalculator;
+        private readonly EnkaClientOptions _options;
 
-        public HSRDataMapper(IHSRAssets assets)
+        public HSRDataMapper(IHSRAssets assets, EnkaClientOptions options)
         {
             _assets = assets ?? throw new ArgumentNullException(nameof(assets));
-            _statCalculator = new HSRStatCalculator(_assets);
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _statCalculator = new HSRStatCalculator(_assets, _options);
         }
 
         public HSRPlayerInfo MapPlayerInfo(HSRApiResponse response)
@@ -102,7 +105,8 @@ namespace EnkaDotNet.Utils.HSR
                 Path = _assets.GetCharacterPath(avatarDetail.AvatarId),
                 Rarity = _assets.GetCharacterRarity(avatarDetail.AvatarId),
                 IconUrl = _assets.GetCharacterIconUrl(avatarDetail.AvatarId),
-                AvatarIconUrl = _assets.GetCharacterAvatarIconUrl(avatarDetail.AvatarId)
+                AvatarIconUrl = _assets.GetCharacterAvatarIconUrl(avatarDetail.AvatarId),
+                Options = this._options
             };
 
             character.SetAssets(_assets);
@@ -141,7 +145,8 @@ namespace EnkaDotNet.Utils.HSR
                     {
                         PointId = skillTreeModel.PointId,
                         Level = skillTreeModel.Level,
-                        BaseLevel = skillTreeModel.Level
+                        BaseLevel = skillTreeModel.Level,
+                        Options = this._options
                     };
 
                     var pointInfo = _assets.GetSkillTreePointInfo(skillTree.PointId.ToString());
@@ -217,7 +222,8 @@ namespace EnkaDotNet.Utils.HSR
                 Rank = equipment.Rank,
                 Path = _assets.GetLightConePath(equipment.Id),
                 Rarity = _assets.GetLightConeRarity(equipment.Id),
-                IconUrl = _assets.GetLightConeIconUrl(equipment.Id)
+                IconUrl = _assets.GetLightConeIconUrl(equipment.Id),
+                Options = this._options
             };
 
             if (equipment.Flat?.Props != null)
@@ -234,7 +240,8 @@ namespace EnkaDotNet.Utils.HSR
                         Type = prop.Type,
                         PropertyType = HSRStatPropertyUtils.MapToStatPropertyType(prop.Type),
                         Value = prop.Value,
-                        IsPercentage = isPercentage
+                        IsPercentage = isPercentage,
+                        Options = this._options
                     });
                 }
             }
@@ -270,7 +277,8 @@ namespace EnkaDotNet.Utils.HSR
                 SetId = relicModel.Flat?.SetId ?? 0,
                 SetName = GetLocalizedRelicSetName(relicModel.Flat?.SetName, relicModel.Flat?.SetId ?? 0),
                 Rarity = _assets.GetRelicRarity(relicModel.Id),
-                IconUrl = _assets.GetRelicIconUrl(relicModel.Id)
+                IconUrl = _assets.GetRelicIconUrl(relicModel.Id),
+                Options = this._options
             };
 
             if (relicModel.Flat?.Props != null && relicModel.Flat.Props.Count > 0)
@@ -285,17 +293,18 @@ namespace EnkaDotNet.Utils.HSR
                         PropertyType = HSRStatPropertyUtils.MapToStatPropertyType(mainProp.Type),
                         Value = mainProp.Value,
                         BaseValue = mainProp.Value,
-                        IsPercentage = isPercentage
+                        IsPercentage = isPercentage,
+                        Options = this._options
                     };
                 }
                 else
                 {
-                    relic.MainStat = new HSRStatProperty { Type = "None", PropertyType = StatPropertyType.None };
+                    relic.MainStat = new HSRStatProperty { Type = "None", PropertyType = StatPropertyType.None, Options = this._options };
                 }
             }
             else
             {
-                relic.MainStat = new HSRStatProperty { Type = "None", PropertyType = StatPropertyType.None };
+                relic.MainStat = new HSRStatProperty { Type = "None", PropertyType = StatPropertyType.None, Options = this._options };
             }
 
             if (relicModel.Flat?.Props != null && relicModel.Flat.Props.Count > 1)
@@ -312,7 +321,8 @@ namespace EnkaDotNet.Utils.HSR
                             PropertyType = HSRStatPropertyUtils.MapToStatPropertyType(subProp.Type),
                             Value = subProp.Value,
                             BaseValue = subProp.Value,
-                            IsPercentage = isPercentage
+                            IsPercentage = isPercentage,
+                            Options = this._options
                         });
                     }
                 }

--- a/EnkaDotNet/Utils/HSR/HSRStatPropertyUtils.cs
+++ b/EnkaDotNet/Utils/HSR/HSRStatPropertyUtils.cs
@@ -26,14 +26,8 @@ namespace EnkaDotNet.Utils.HSR
             { "Effect RES", "StatusResistance" },
             { "Break Effect", "BreakDamageAddedRatio" },
             { "Energy Regeneration Rate", "SPRatioBase" },
-            { "Outgoing Healing", "HealRatioBase" },
-            { "Physical DMG", "PhysicalAddedRatio" },
-            { "Fire DMG", "FireAddedRatio" },
-            { "Ice DMG", "IceAddedRatio" },
-            { "Lightning DMG", "ThunderAddedRatio" },
-            { "Wind DMG", "WindAddedRatio" },
-            { "Quantum DMG", "QuantumAddedRatio" },
-            { "Imaginary DMG", "ImaginaryAddedRatio" }
+            { "Outgoing Healing", "HealRatioBase" }
+
         };
 
         private static readonly Dictionary<string, string> PropertyTypeToDisplayName = new Dictionary<string, string>();
@@ -61,23 +55,90 @@ namespace EnkaDotNet.Utils.HSR
             { "WindAddedRatio", true },
             { "QuantumAddedRatio", true },
             { "ImaginaryAddedRatio", true },
+
             { "CriticalChanceBase", true },
             { "CriticalDamageBase", true },
             { "BreakDamageAddedRatioBase", true }
+
         };
+
+
+        private static readonly Dictionary<string, string> FinalStatKeyToDisplayName = new Dictionary<string, string>
+        {
+            { "HP", "HP" },
+            { "Attack", "ATK" },
+            { "Defense", "DEF" },
+            { "Speed", "SPD" },
+            { "CritRate", "CRIT Rate" },
+            { "CritDMG", "CRIT DMG" },
+            { "BreakEffect", "Break Effect" },
+            { "HealingBoost", "Outgoing Healing" },
+            { "EnergyRegenRate", "Energy Regeneration Rate" },
+            { "EffectHitRate", "Effect Hit Rate" },
+            { "EffectResistance", "Effect RES" },
+            { "PhysicalDamageBoost", "Physical DMG" },
+            { "FireDamageBoost", "Fire DMG" },
+            { "IceDamageBoost", "Ice DMG" },
+            { "LightningDamageBoost", "Lightning DMG" },
+            { "WindDamageBoost", "Wind DMG" },
+            { "QuantumDamageBoost", "Quantum DMG" },
+            { "ImaginaryDamageBoost", "Imaginary DMG" }
+        };
+
 
         static HSRStatPropertyUtils()
         {
+
             foreach (var kvp in DisplayNameToPropertyType)
             {
-                PropertyTypeToDisplayName[kvp.Value] = kvp.Key;
+
+                if (!PropertyTypeToDisplayName.ContainsKey(kvp.Value))
+                {
+                    PropertyTypeToDisplayName[kvp.Value] = kvp.Key;
+                }
             }
+
+
+            PropertyTypeToDisplayName["CriticalChanceBase"] = "CRIT Rate";
+            PropertyTypeToDisplayName["CriticalDamageBase"] = "CRIT DMG";
+            PropertyTypeToDisplayName["BreakDamageAddedRatioBase"] = "Break Effect";
+            PropertyTypeToDisplayName["SPRatioBase"] = "Energy Regeneration Rate";
+            PropertyTypeToDisplayName["HealRatioBase"] = "Outgoing Healing";
+            PropertyTypeToDisplayName["StatusProbability"] = "Effect Hit Rate";
+            PropertyTypeToDisplayName["StatusResistance"] = "Effect RES";
+
+
+            PropertyTypeToDisplayName["PhysicalAddedRatio"] = "Physical DMG";
+            PropertyTypeToDisplayName["FireAddedRatio"] = "Fire DMG";
+            PropertyTypeToDisplayName["IceAddedRatio"] = "Ice DMG";
+            PropertyTypeToDisplayName["ThunderAddedRatio"] = "Lightning DMG";
+            PropertyTypeToDisplayName["WindAddedRatio"] = "Wind DMG";
+            PropertyTypeToDisplayName["QuantumAddedRatio"] = "Quantum DMG";
+            PropertyTypeToDisplayName["ImaginaryAddedRatio"] = "Imaginary DMG";
+
+
+            PropertyTypeToDisplayName["HPDelta"] = "HP";
+            PropertyTypeToDisplayName["HPAddedRatio"] = "HP%";
+            PropertyTypeToDisplayName["AttackDelta"] = "ATK";
+            PropertyTypeToDisplayName["AttackAddedRatio"] = "ATK%";
+            PropertyTypeToDisplayName["DefenceDelta"] = "DEF";
+            PropertyTypeToDisplayName["DefenceAddedRatio"] = "DEF%";
+            PropertyTypeToDisplayName["SpeedDelta"] = "SPD";
+
+
+            PropertyTypeToDisplayName["BaseHP"] = "Base HP";
+            PropertyTypeToDisplayName["BaseAttack"] = "Base ATK";
+            PropertyTypeToDisplayName["BaseDefence"] = "Base DEF";
+            PropertyTypeToDisplayName["BaseSpeed"] = "Base SPD";
         }
 
         public static bool IsPercentageType(string propertyType)
         {
-            return IsPercentProperty.TryGetValue(propertyType, out bool isPercent) && isPercent;
+
+            return (IsPercentProperty.TryGetValue(propertyType, out bool isPercent) && isPercent)
+                   || (PropertyTypeToDisplayName.TryGetValue(propertyType, out var name) && name.EndsWith("%"));
         }
+
 
         public static string GetDisplayName(string propertyType)
         {
@@ -85,6 +146,15 @@ namespace EnkaDotNet.Utils.HSR
                 ? displayName
                 : propertyType;
         }
+
+
+        public static string GetFinalStatDisplayName(string finalStatKey)
+        {
+            return FinalStatKeyToDisplayName.TryGetValue(finalStatKey, out string displayName)
+               ? displayName
+               : finalStatKey;
+        }
+
 
         public static string GetPropertyType(string displayName)
         {
@@ -99,15 +169,20 @@ namespace EnkaDotNet.Utils.HSR
 
             if (isPercent)
             {
-                return $"{value * 100:F1}%";
+
+
+                double displayValue = value > 1.0 ? value : value * 100;
+                return $"{displayValue:F1}%";
             }
-            else if (propertyType == "SpeedDelta")
+            else if (propertyType == "SpeedDelta" || propertyType == "BaseSpeed")
             {
+
                 return $"{value:F1}";
             }
             else
             {
-                return $"{(int)value}";
+
+                return $"{(int)Math.Floor(value)}";
             }
         }
 
@@ -117,6 +192,7 @@ namespace EnkaDotNet.Utils.HSR
 
             if (isPercent)
             {
+
                 return displayValue / 100.0;
             }
 
@@ -152,6 +228,7 @@ namespace EnkaDotNet.Utils.HSR
                 case "ImaginaryAddedRatio": return StatPropertyType.ImaginaryAddedRatio;
                 case "HealRatioBase": return StatPropertyType.HealRatioBase;
                 case "SPRatioBase": return StatPropertyType.SPRatioBase;
+
                 case "CriticalChanceBase": return StatPropertyType.CriticalChanceBase;
                 case "CriticalDamageBase": return StatPropertyType.CriticalDamageBase;
                 case "BreakDamageAddedRatioBase": return StatPropertyType.BreakDamageAddedRatioBase;
@@ -159,19 +236,11 @@ namespace EnkaDotNet.Utils.HSR
             }
         }
 
+
+
         public static double GetPropertyScalingFactor(string propertyType)
         {
-            switch (propertyType)
-            {
-                case "HPAddedRatio": return 100.0;
-                case "AttackAddedRatio": return 100.0;
-                case "DefenceAddedRatio": return 100.0;
-                case "CriticalChance": return 100.0;
-                case "CriticalDamage": return 100.0;
-                case "StatusProbability": return 100.0;
-                case "StatusResistance": return 100.0;
-                default: return IsPercentageType(propertyType) ? 100.0 : 1.0;
-            }
+            return IsPercentageType(propertyType) ? 100.0 : 1.0;
         }
     }
 }

--- a/EnkaDotNet/Utils/HSR/HSRStatsCalculator.cs
+++ b/EnkaDotNet/Utils/HSR/HSRStatsCalculator.cs
@@ -8,12 +8,14 @@ using System.Threading.Tasks;
 using EnkaDotNet.Assets.HSR;
 using EnkaDotNet.Components.HSR;
 using EnkaDotNet.Enums.HSR;
+using System.Globalization;
 
 namespace EnkaDotNet.Utils.HSR
 {
     public class HSRStatCalculator
     {
         private readonly IHSRAssets _assets;
+        private readonly EnkaClientOptions _options;
         private static readonly Dictionary<string, double> DEFAULT_STATS = new Dictionary<string, double>
         {
             { "HPBase", 0 }, { "HPDelta", 0 }, { "HPAddedRatio", 0 },
@@ -36,9 +38,10 @@ namespace EnkaDotNet.Utils.HSR
             { "ImaginaryAddedRatio", 0 }
         };
 
-        public HSRStatCalculator(IHSRAssets assets)
+        public HSRStatCalculator(IHSRAssets assets, EnkaClientOptions options)
         {
             _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         public Dictionary<string, HSRStatValue> CalculateCharacterStats(HSRCharacter character)
@@ -239,58 +242,58 @@ namespace EnkaDotNet.Utils.HSR
             double hpAddedRatio = stats.ContainsKey("HPAddedRatio") ? stats["HPAddedRatio"] : 0;
             double hpDelta = stats.ContainsKey("HPDelta") ? stats["HPDelta"] : 0;
             double finalHP = Math.Floor(baseHP * (1.0 + hpAddedRatio) + hpDelta);
-            finalStats["HP"] = new HSRStatValue(finalHP, false, 0);
+            finalStats["HP"] = new HSRStatValue(finalHP, _options, false, 0);
 
             double baseAtk = stats.ContainsKey("AttackBase") ? stats["AttackBase"] : 0;
             double atkAddedRatio = stats.ContainsKey("AttackAddedRatio") ? stats["AttackAddedRatio"] : 0;
             double atkDelta = stats.ContainsKey("AttackDelta") ? stats["AttackDelta"] : 0;
             double finalATK = Math.Floor(baseAtk * (1.0 + atkAddedRatio) + atkDelta);
-            finalStats["Attack"] = new HSRStatValue(finalATK, false, 0);
+            finalStats["Attack"] = new HSRStatValue(finalATK, _options, false, 0);
 
             double baseDef = stats.ContainsKey("DefenceBase") ? stats["DefenceBase"] : 0;
             double defAddedRatio = stats.ContainsKey("DefenceAddedRatio") ? stats["DefenceAddedRatio"] : 0;
             double defDelta = stats.ContainsKey("DefenceDelta") ? stats["DefenceDelta"] : 0;
             double finalDEF = Math.Floor(baseDef * (1.0 + defAddedRatio) + defDelta);
-            finalStats["Defense"] = new HSRStatValue(finalDEF, false, 0);
+            finalStats["Defense"] = new HSRStatValue(finalDEF, _options, false, 0);
 
             double baseSpd = stats.ContainsKey("SpeedBase") ? stats["SpeedBase"] : 0;
             double spdDelta = stats.ContainsKey("SpeedDelta") ? stats["SpeedDelta"] : 0;
             double spdAddedRatio = stats.ContainsKey("SpeedAddedRatio") ? stats["SpeedAddedRatio"] : 0;
             double finalSPD = Math.Round((baseSpd * (1.0 + spdAddedRatio) + spdDelta), 1);
-            finalStats["Speed"] = new HSRStatValue(finalSPD, false, 1);
+            finalStats["Speed"] = new HSRStatValue(finalSPD, _options, false, 1);
 
             double criticalChance = stats.ContainsKey("CriticalChance") ? stats["CriticalChance"] : 0;
             double criticalChanceBase = stats.ContainsKey("CriticalChanceBase") ? stats["CriticalChanceBase"] : 0;
             double finalCritRate = Math.Round((criticalChance + criticalChanceBase) * 100.0, 1);
-            finalStats["CritRate"] = new HSRStatValue(finalCritRate, true, 1);
+            finalStats["CritRate"] = new HSRStatValue(finalCritRate, _options, true, 1);
 
             double criticalDamage = stats.ContainsKey("CriticalDamage") ? stats["CriticalDamage"] : 0;
             double criticalDamageBase = stats.ContainsKey("CriticalDamageBase") ? stats["CriticalDamageBase"] : 0;
             double finalCritDMG = Math.Round((criticalDamage + criticalDamageBase) * 100.0, 1);
-            finalStats["CritDMG"] = new HSRStatValue(finalCritDMG, true, 1);
+            finalStats["CritDMG"] = new HSRStatValue(finalCritDMG, _options, true, 1);
 
             double breakDamage = stats.ContainsKey("BreakDamageAddedRatio") ? stats["BreakDamageAddedRatio"] : 0;
             double breakDamageBase = stats.ContainsKey("BreakDamageAddedRatioBase") ? stats["BreakDamageAddedRatioBase"] : 0;
             double finalBreakEffect = Math.Round((breakDamage + breakDamageBase) * 100.0, 1);
-            finalStats["BreakEffect"] = new HSRStatValue(finalBreakEffect, true, 1);
+            finalStats["BreakEffect"] = new HSRStatValue(finalBreakEffect, _options, true, 1);
 
             double healRatio = stats.ContainsKey("HealRatioBase") ? stats["HealRatioBase"] : 0;
             double finalHealingBoost = Math.Round(healRatio * 100.0, 1);
-            finalStats["HealingBoost"] = new HSRStatValue(finalHealingBoost, true, 1);
+            finalStats["HealingBoost"] = new HSRStatValue(finalHealingBoost, _options, true, 1);
 
             double spRatio = stats.ContainsKey("SPRatioBase") ? stats["SPRatioBase"] : 0;
             double finalEnergyRegenRate = Math.Round((1.0 + spRatio) * 100.0, 1);
-            finalStats["EnergyRegenRate"] = new HSRStatValue(finalEnergyRegenRate, true, 1);
+            finalStats["EnergyRegenRate"] = new HSRStatValue(finalEnergyRegenRate, _options, true, 1);
 
             double statusProbability = stats.ContainsKey("StatusProbability") ? stats["StatusProbability"] : 0;
             double statusProbabilityBase = stats.ContainsKey("StatusProbabilityBase") ? stats["StatusProbabilityBase"] : 0;
             double finalEffectHitRate = Math.Round((statusProbability + statusProbabilityBase) * 100.0, 1);
-            finalStats["EffectHitRate"] = new HSRStatValue(finalEffectHitRate, true, 1);
+            finalStats["EffectHitRate"] = new HSRStatValue(finalEffectHitRate, _options, true, 1);
 
             double statusResistance = stats.ContainsKey("StatusResistance") ? stats["StatusResistance"] : 0;
             double statusResistanceBase = stats.ContainsKey("StatusResistanceBase") ? stats["StatusResistanceBase"] : 0;
             double finalEffectResistance = Math.Round((statusResistance + statusResistanceBase) * 100.0, 1);
-            finalStats["EffectResistance"] = new HSRStatValue(finalEffectResistance, true, 1);
+            finalStats["EffectResistance"] = new HSRStatValue(finalEffectResistance, _options, true, 1);
 
             Dictionary<string, string> elementMapping = new Dictionary<string, string>
             {
@@ -308,7 +311,7 @@ namespace EnkaDotNet.Utils.HSR
                 string propName = $"{elem.Key}AddedRatio";
                 double valueDecimal = stats.ContainsKey(propName) ? stats[propName] : 0;
                 double valuePercent = Math.Round(valueDecimal * 100.0, 1);
-                finalStats[elem.Value] = new HSRStatValue(valuePercent, true, 1);
+                finalStats[elem.Value] = new HSRStatValue(valuePercent, _options, true, 1);
             }
 
             return finalStats;

--- a/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
@@ -181,23 +181,16 @@ namespace EnkaDotNet.Utils.ZZZ
             if (ZZZStatsHelpers.IsCalculationPercentageStat(statType) &&
                 statType != StatType.CritRateBase &&
                 statType != StatType.CritDMGBase &&
-                statType != StatType.EnergyRegenBase)
+                statType != StatType.EnergyRegenBase &&
+                 statType != StatType.EnergyRegenPercent)
             {
                 calculationValue = rawValue / 100.0;
             }
-
-            double formattedValue = calculationValue;
-            if (level > 0)
-            {
-                formattedValue *= level;
-            }
-
 
             return new ZZZStat
             {
                 Type = statType,
                 Value = calculationValue,
-                FormattedValue = formattedValue,
                 Level = level,
                 IsPercentage = isPercentage
             };

--- a/EnkaDotNet/Utils/ZZZ/ZZZStatsHelpers.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZStatsHelpers.cs
@@ -18,6 +18,7 @@ namespace EnkaDotNet.Utils.ZZZ
         private const double BASE_ENERGY_REGEN = 0;
         private static readonly IZZZAssets assets = new ZZZAssets();
 
+
         public static Dictionary<string, double> CalculateAllTotalStats(ZZZAgent agent)
         {
             var breakdown = CalculateTotalBreakdown(agent, assets);
@@ -28,12 +29,13 @@ namespace EnkaDotNet.Utils.ZZZ
             );
         }
 
+
         public static bool IsDisplayPercentageStatForGroup(string statGroup)
         {
             switch (statGroup)
             {
-                case "Crit Rate":
-                case "Crit DMG":
+                case "CRIT Rate":
+                case "CRIT DMG":
                 case "Pen Ratio":
                 case "Physical DMG":
                 case "Fire DMG":
@@ -46,13 +48,14 @@ namespace EnkaDotNet.Utils.ZZZ
             }
         }
 
+
         public static bool IsDisplayPercentageStat(StatType statType)
         {
             string category = GetStatCategoryDisplay(statType);
             switch (category)
             {
-                case "Crit Rate":
-                case "Crit DMG":
+                case "CRIT Rate":
+                case "CRIT DMG":
                 case "Pen Ratio":
                 case "Physical DMG":
                 case "Fire DMG":
@@ -61,13 +64,13 @@ namespace EnkaDotNet.Utils.ZZZ
                 case "Ether DMG":
                 case "HP%":
                 case "ATK%":
-                case "Def%":
+                case "DEF%":
                 case "Impact%":
                     return true;
                 case "Energy Regen":
                 case "HP":
                 case "ATK":
-                case "Def":
+                case "DEF":
                 case "Impact":
                 case "Anomaly Mastery":
                 case "Anomaly Proficiency":
@@ -76,6 +79,7 @@ namespace EnkaDotNet.Utils.ZZZ
                     return false;
             }
         }
+
 
         public static bool IsCalculationPercentageStat(StatType statType)
         {
@@ -111,6 +115,7 @@ namespace EnkaDotNet.Utils.ZZZ
             }
         }
 
+
         private static Dictionary<string, Dictionary<string, double>> CalculateTotalBreakdown(ZZZAgent agent, IZZZAssets assets)
         {
             var breakdown = InitializeTotalsDictionary();
@@ -132,14 +137,14 @@ namespace EnkaDotNet.Utils.ZZZ
                     double value = agent.Weapon.SecondaryStat.Value;
                     if (value > 1.0)
                         value /= 100.0;
-                    breakdown["Crit Rate"]["Weapon_Flat"] += value;
+                    breakdown["CRIT Rate"]["Weapon_Flat"] += value;
                 }
                 else if (agent.Weapon.SecondaryStat.Type == StatType.CritDMGFlat)
                 {
                     double value = agent.Weapon.SecondaryStat.Value;
                     if (value > 1.0)
                         value /= 100.0;
-                    breakdown["Crit DMG"]["Weapon_Flat"] += value;
+                    breakdown["CRIT DMG"]["Weapon_Flat"] += value;
                 }
                 else if (agent.Weapon.SecondaryStat.Type == StatType.EnergyRegenPercent)
                 {
@@ -160,7 +165,7 @@ namespace EnkaDotNet.Utils.ZZZ
                     if (value > 1.0)
                         value /= 100.0;
 
-                    breakdown["Crit Rate"]["Discs_Flat"] += value;
+                    breakdown["CRIT Rate"]["Discs_Flat"] += value;
                 }
                 else if (disc.MainStat.Type == StatType.CritDMGFlat)
                 {
@@ -168,14 +173,14 @@ namespace EnkaDotNet.Utils.ZZZ
                     if (value > 1.0)
                         value /= 100.0;
 
-                    breakdown["Crit DMG"]["Discs_Flat"] += value;
+                    breakdown["CRIT DMG"]["Discs_Flat"] += value;
                 }
                 else
                 {
                     AddContribution(breakdown, disc.MainStat.Type, disc.MainStat.Value, "Discs");
                 }
 
-                foreach (var subStat in disc.SubStats)
+                foreach (var subStat in disc.SubStatsRaw)
                 {
                     if (subStat.Type == StatType.CritRateFlat)
                     {
@@ -184,7 +189,7 @@ namespace EnkaDotNet.Utils.ZZZ
                             baseValue /= 100.0;
 
                         double scaledValue = baseValue * subStat.Level;
-                        breakdown["Crit Rate"]["Discs_Flat"] += scaledValue;
+                        breakdown["CRIT Rate"]["Discs_Flat"] += scaledValue;
                     }
                     else if (subStat.Type == StatType.CritDMGFlat)
                     {
@@ -193,7 +198,7 @@ namespace EnkaDotNet.Utils.ZZZ
                             baseValue /= 100.0;
 
                         double scaledValue = baseValue * subStat.Level;
-                        breakdown["Crit DMG"]["Discs_Flat"] += scaledValue;
+                        breakdown["CRIT DMG"]["Discs_Flat"] += scaledValue;
                     }
                     else
                     {
@@ -214,7 +219,7 @@ namespace EnkaDotNet.Utils.ZZZ
         {
             var breakdown = new Dictionary<string, Dictionary<string, double>>();
             var statGroups = new List<string> {
-                "HP", "ATK", "Def", "Impact", "Crit Rate", "Crit DMG", "Energy Regen",
+                "HP", "ATK", "DEF", "Impact", "CRIT Rate", "CRIT DMG", "Energy Regen",
                 "Anomaly Mastery", "Anomaly Proficiency", "Pen Ratio", "PEN",
                 "Physical DMG", "Fire DMG", "Ice DMG", "Electric DMG", "Ether DMG"
             };
@@ -231,12 +236,13 @@ namespace EnkaDotNet.Utils.ZZZ
                 };
             }
 
-            breakdown["Crit Rate"]["Agent_Base"] = BASE_CRIT_RATE;
-            breakdown["Crit DMG"]["Agent_Base"] = BASE_CRIT_DMG;
+            breakdown["CRIT Rate"]["Agent_Base"] = BASE_CRIT_RATE;
+            breakdown["CRIT DMG"]["Agent_Base"] = BASE_CRIT_DMG;
             breakdown["Energy Regen"]["Agent_Base"] = BASE_ENERGY_REGEN;
 
             return breakdown;
         }
+
 
         private static void AddContribution(Dictionary<string, Dictionary<string, double>> breakdown, StatType statType, double value, string sourcePrefix)
         {
@@ -246,12 +252,12 @@ namespace EnkaDotNet.Utils.ZZZ
             string targetBucketSuffix;
             double valueToAdd = value;
 
-            if (category == "Crit Rate" || category == "Crit DMG")
+            if (category == "CRIT Rate" || category == "CRIT DMG")
             {
                 if (sourcePrefix == "Agent" && statType.ToString().EndsWith("Base"))
                 {
                     targetBucketSuffix = "Base";
-                    valueToAdd = (category == "Crit Rate") ? BASE_CRIT_RATE : BASE_CRIT_DMG;
+                    valueToAdd = (category == "CRIT Rate") ? BASE_CRIT_RATE : BASE_CRIT_DMG;
                 }
                 else if (sourcePrefix != "Agent")
                 {
@@ -333,6 +339,7 @@ namespace EnkaDotNet.Utils.ZZZ
             breakdown[category][bucketKey] += valueToAdd;
         }
 
+
         private static void ApplySetBonuses(ZZZAgent agent, Dictionary<string, Dictionary<string, double>> breakdown, IZZZAssets assets)
         {
             var equippedSets = agent.EquippedDiscs
@@ -363,7 +370,7 @@ namespace EnkaDotNet.Utils.ZZZ
                             rawValue = rawValue / 1000.0;
                             breakdown["Energy Regen"]["SetBonus_Percent"] += rawValue;
                         }
-                        else if (category == "Crit Rate" || category == "Crit DMG")
+                        else if (category == "CRIT Rate" || category == "CRIT DMG")
                         {
                             rawValue = rawValue / 1000.0;
                             breakdown[category]["SetBonus_Flat"] += rawValue;
@@ -381,6 +388,7 @@ namespace EnkaDotNet.Utils.ZZZ
                 }
             }
         }
+
 
         private static void CalculateFinalValues(Dictionary<string, Dictionary<string, double>> breakdown)
         {
@@ -404,7 +412,7 @@ namespace EnkaDotNet.Utils.ZZZ
                 {
                     case "HP":
                         double percentBonus = agentBase * totalPercentBonus;
-                        finalValue = Math.Floor(agentBase + percentBonus + totalFlatBonus);
+                        finalValue = Math.Ceiling(agentBase + percentBonus + totalFlatBonus);
                         catBreakdown["BaseDisplay"] = agentBase;
                         catBreakdown["AddedDisplay"] = finalValue - agentBase;
                         break;
@@ -430,7 +438,7 @@ namespace EnkaDotNet.Utils.ZZZ
                         catBreakdown["AddedDisplay"] = finalValue - combinedBaseATK;
                         break;
 
-                    case "Def":
+                    case "DEF":
                         double defDiscPercentBonus = catBreakdown["Discs_Percent"] != 0 ? catBreakdown["Discs_Percent"] / 100.0 : 0;
                         double defWeaponPercentBonus = catBreakdown["Weapon_Percent"] != 0 ? catBreakdown["Weapon_Percent"] / 100.0 : 0;
                         double defAgentPercentBonus = catBreakdown["Agent_Percent"] != 0 ? catBreakdown["Agent_Percent"] / 100.0 : 0;
@@ -530,14 +538,14 @@ namespace EnkaDotNet.Utils.ZZZ
                         catBreakdown["AddedDisplay"] = finalValue - agentBase;
                         break;
 
-                    case "Crit Rate":
+                    case "CRIT Rate":
                         finalValue = (BASE_CRIT_RATE + totalFlatBonus + totalPercentBonus + bonusFlat) * 100;
                         catBreakdown["BaseDisplay"] = (BASE_CRIT_RATE * 100);
                         catBreakdown["AddedDisplay"] = finalValue - (BASE_CRIT_RATE * 100);
                         break;
 
-                    case "Crit DMG":
-                        finalValue = (BASE_CRIT_DMG + totalFlatBonus + totalPercentBonus + bonusFlat) * 100;        
+                    case "CRIT DMG":
+                        finalValue = (BASE_CRIT_DMG + totalFlatBonus + totalPercentBonus + bonusFlat) * 100;
                         catBreakdown["BaseDisplay"] = (BASE_CRIT_DMG * 100);
                         catBreakdown["AddedDisplay"] = finalValue - (BASE_CRIT_DMG * 100);
                         break;
@@ -588,17 +596,18 @@ namespace EnkaDotNet.Utils.ZZZ
             }
         }
 
+
         public static string GetStatCategory(StatType statType)
         {
             switch (statType)
             {
                 case StatType.HPBase: case StatType.HPPercent: case StatType.HPFlat: return "HP";
                 case StatType.ATKBase: case StatType.ATKPercent: case StatType.ATKFlat: return "ATK";
-                case StatType.DefBase: case StatType.DefPercent: case StatType.DefFlat: return "Def";
+                case StatType.DefBase: case StatType.DefPercent: case StatType.DefFlat: return "DEF";
                 case StatType.ImpactBase: case StatType.ImpactPercent: return "Impact";
 
-                case StatType.CritRateBase: case StatType.CritRateFlat: return "Crit Rate";
-                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "Crit DMG";
+                case StatType.CritRateBase: case StatType.CritRateFlat: return "CRIT Rate";
+                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "CRIT DMG";
 
                 case StatType.EnergyRegenBase: case StatType.EnergyRegenPercent: case StatType.EnergyRegenFlat: return "Energy Regen";
 
@@ -617,6 +626,7 @@ namespace EnkaDotNet.Utils.ZZZ
                 default: return "";
             }
         }
+
 
         public static string GetStatCategoryDisplay(StatType statType)
         {
@@ -624,16 +634,16 @@ namespace EnkaDotNet.Utils.ZZZ
             {
                 case StatType.HPBase: case StatType.HPFlat: return "HP";
                 case StatType.ATKBase: case StatType.ATKFlat: return "ATK";
-                case StatType.DefBase: case StatType.DefFlat: return "Def";
+                case StatType.DefBase: case StatType.DefFlat: return "DEF";
                 case StatType.ImpactBase: return "Impact";
 
                 case StatType.HPPercent: return "HP%";
                 case StatType.ATKPercent: return "ATK%";
-                case StatType.DefPercent: return "Def%";
+                case StatType.DefPercent: return "DEF%";
                 case StatType.ImpactPercent: return "Impact%";
 
-                case StatType.CritRateBase: case StatType.CritRateFlat: return "Crit Rate";
-                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "Crit DMG";
+                case StatType.CritRateBase: case StatType.CritRateFlat: return "CRIT Rate";
+                case StatType.CritDMGBase: case StatType.CritDMGFlat: return "CRIT DMG";
 
                 case StatType.EnergyRegenBase: case StatType.EnergyRegenPercent: case StatType.EnergyRegenFlat: return "Energy Regen";
 
@@ -652,6 +662,7 @@ namespace EnkaDotNet.Utils.ZZZ
                 default: return "";
             }
         }
+
 
         public static StatBreakdown GetStatSourceBreakdown(ZZZAgent agent, string statGroup)
         {
@@ -669,11 +680,11 @@ namespace EnkaDotNet.Utils.ZZZ
 
             result.TotalValue = catBreakdown["Final"];
 
-            if (statGroup == "Crit Rate")
+            if (statGroup == "CRIT Rate")
             {
                 result.BaseValue = (BASE_CRIT_RATE * 100);
             }
-            else if (statGroup == "Crit DMG")
+            else if (statGroup == "CRIT DMG")
             {
                 result.BaseValue = (BASE_CRIT_DMG * 100);
             }
@@ -702,6 +713,31 @@ namespace EnkaDotNet.Utils.ZZZ
             }
 
             return result;
+        }
+
+        public static StatType GetStatTypeFromFriendlyName(string friendlyName, bool isPercentage, bool isEnergyRegen = false)
+        {
+            if (isEnergyRegen) return StatType.EnergyRegenPercent;
+
+            switch (friendlyName)
+            {
+                case "HP": return isPercentage ? StatType.HPPercent : StatType.HPFlat;
+                case "ATK": return isPercentage ? StatType.ATKPercent : StatType.ATKFlat;
+                case "DEF": return isPercentage ? StatType.DefPercent : StatType.DefFlat;
+                case "Impact": return isPercentage ? StatType.ImpactPercent : StatType.ImpactBase;
+                case "CRIT Rate": return StatType.CritRateFlat;
+                case "CRIT DMG": return StatType.CritDMGFlat;
+                case "Anomaly Mastery": return StatType.AnomalyMasteryFlat;
+                case "Anomaly Proficiency": return StatType.AnomalyProficiencyFlat;
+                case "Pen Ratio": return StatType.PenRatioFlat;
+                case "PEN": return StatType.PENFlat;
+                case "Physical DMG": return StatType.PhysicalDMGBonusFlat;
+                case "Fire DMG": return StatType.FireDMGBonusFlat;
+                case "Ice DMG": return StatType.IceDMGBonusFlat;
+                case "Electric DMG": return StatType.ElectricDMGBonusFlat;
+                case "Ether DMG": return StatType.EtherDMGBonusFlat;
+                default: return StatType.None;
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Enka.DotNet is a wrapper for accessing and processing character data from the En
 
 - Fetch detailed character builds including artifacts, weapons, stats, and constellations  
 - Access player profile information, including namecards and achievements  
-- Strong typing for all Genshin Impact game entities
+- Retrieve comprehensive agent details, including stats, weapons, and drive disc sets for Zenless Zone Zero  
+- View detailed character stats, relics, light cones, and skill trees for Honkai Star Rail
+- Strongly typed models for all Hoyoverse game entities
 - Support for multiple games: Genshin Impact, Honkai: Star Rail, and Zenless Zone Zero
 
 ## Supported Games  
@@ -33,141 +35,148 @@ Or via the .NET CLI:
 dotnet add package EnkaDotNet
 ```
 
-## Important Notice  
-
-If you encounter the following error: Please ensure you have the correct version of Newtonsoft.Json installed or Could not load file or assembly 'Newtonsoft.Json'... 
-You can resolve this by running:
-```
-Install-Package Newtonsoft.Json -Version 13.0.3
-```
-Alternatively, update the package to the latest version if it is already installed.
-
 ## Example Code for Genshin Impact
 
 ```csharp
 using EnkaDotNet;
-using EnkaDotNet.Enums.Genshin;
 
-var options = new EnkaClientOptions
+namespace GenshinStatsViewer
 {
-    Language = "ja",
-    UserAgent = "EnkaDotNet/1.5",
-};
-
-using var client = new EnkaClient(options);
-
-try
-{
-    int uid = 829344442;
-
-    Console.OutputEncoding = System.Text.Encoding.UTF8;
-
-    Console.WriteLine($"Fetching profile for UID {uid}...");
-
-    var (player, characters) = await client.GetUserProfile(uid);
-
-    Console.WriteLine($"\nPlayer: {player.Nickname} (AR {player.Level})");
-    Console.WriteLine($"World Level: {player.WorldLevel}");
-    Console.WriteLine($"Signature: {player.Signature}");
-    Console.WriteLine($"IconUrl: {player.IconUrl}");
-    Console.WriteLine($"NameCard: {player.NameCardIcon} | {player.NameCardId}");
-    Console.WriteLine($"Characters in profile: {characters.Count}");
-
-    // Print Abyss data
-    Console.WriteLine("\nAbyss data:");
-    Console.WriteLine($"Spiral Abyss Floor: {player.Challenge?.SpiralAbyss?.Floor}");
-    Console.WriteLine($"Spiral Abyss Chamber: {player.Challenge?.SpiralAbyss?.Chamber}");
-    Console.WriteLine($"Spiral Abyss Stars: {player.Challenge?.SpiralAbyss?.Star}");
-
-    // Print Theater data
-    Console.WriteLine("\nTheater data:");
-    Console.WriteLine($"Theater Mechanicus Act: {player.Challenge?.Theater?.Act}");
-    Console.WriteLine($"Theater Mechanicus Stars: {player.Challenge?.Theater?.Star}");
-
-    // Print Namecards
-    Console.WriteLine("\nNamecards Showcase:");
-    foreach (var namecard in player.ShowcaseNameCards)
+    class Program
     {
-        Console.WriteLine($"Icon: {namecard.IconUrl} | ID: {namecard.Id}");
-    }
-
-    Console.WriteLine("\nCharacter Details:");
-    foreach (var character in characters)
-    {
-        Console.WriteLine($"\n{character.Name} | Level {character.Level} | C{character.ConstellationLevel}");
-
-        if (character.Weapon != null)
+        static async Task Main(string[] args)
         {
-            Console.WriteLine($"Weapon: {character.Weapon.Name} | R{character.Weapon.Refinement} | Level {character.Weapon.Level}");
-            Console.WriteLine($"Base ATK: {character.Weapon.BaseAttack} | Substat: {character.Weapon.SecondaryStat?.Value} | Type: {character.Weapon.SecondaryStat?.Type}");
-            Console.WriteLine($"Icon: {character.Weapon.IconUrl}");
-        }
-
-        // Print all stats
-        Console.WriteLine("\nStats:");
-        var stats = character.GetStats();
-        foreach (var category in stats)
-        {
-            Console.WriteLine($"{category.Key}:");
-            foreach (var stat in category.Value)
+            try
             {
-                Console.WriteLine($"  {stat.Key}: {stat.Value.Formatted} ({stat.Value.Raw})");
+                var options = new EnkaClientOptions
+                {
+                    Language = "ja",
+                    GameType = EnkaDotNet.Enums.GameType.Genshin,
+                    EnableCaching = true,
+                    UserAgent = "EnkaDotNet/5.0",
+                };
+
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
+
+                using var client = new EnkaClient(options);
+
+                int uid = args.Length > 0 && int.TryParse(args[0], out int parsedUid) ? parsedUid : 829344442;
+
+                Console.WriteLine($"Fetching data for UID: {uid}...");
+
+                var (playerInfo, characters) = await client.GetUserProfile(uid);
+
+                Console.WriteLine($"\nPlayer: {playerInfo.Nickname} (Lv.{playerInfo.Level}, WL{playerInfo.WorldLevel})");
+                Console.WriteLine($"Signature: {playerInfo.Signature}");
+                Console.WriteLine($"Achievements: {playerInfo.FinishedAchievements}");
+                if (playerInfo.Challenge?.SpiralAbyss != null)
+                {
+                    Console.WriteLine($"Spiral Abyss: Floor {playerInfo.Challenge.SpiralAbyss.Floor}-{playerInfo.Challenge.SpiralAbyss.Chamber} ({playerInfo.Challenge.SpiralAbyss.Star} Stars)");
+                }
+                if (playerInfo.Challenge?.Theater != null)
+                {
+                    Console.WriteLine($"Imaginarium Theater: Act {playerInfo.Challenge.Theater.Act} ({playerInfo.Challenge.Theater.Star} Stars)");
+                }
+
+                Console.WriteLine($"\nCharacters ({characters.Count}):");
+
+                if (!characters.Any())
+                {
+                    Console.WriteLine("No characters found or profile is private.");
+                }
+
+                foreach (var character in characters)
+                {
+                    Console.WriteLine($"\n--- {character.Name} (Lv.{character.Level}/{character.Ascension}) ---");
+                    Console.WriteLine($"Element: {character.Element}");
+                    Console.WriteLine($"Friendship: {character.Friendship}");
+                    Console.WriteLine($"Constellation: C{character.ConstellationLevel}");
+                    Console.WriteLine($"Icon: {character.IconUrl}");
+
+                    Console.WriteLine("\n  STATS:");
+                    foreach (var stat in character.GetAllStats())
+                    {
+                        Console.WriteLine($"    {stat.Key}: {stat.Value}");
+                    }
+
+                    Console.WriteLine("\n  WEAPON:");
+                    if (character.Weapon != null)
+                    {
+                        var weapon = character.Weapon;
+                        Console.WriteLine($"    {weapon.Name} (Lv.{weapon.Level}/{weapon.Ascension}, R{weapon.Refinement})");
+                        Console.WriteLine($"      Type: {weapon.Type}");
+                        Console.WriteLine($"      Rarity: {weapon.Rarity}");
+                        Console.WriteLine($"      Icon: {weapon.IconUrl}");
+                        Console.WriteLine($"      {weapon.FormattedBaseAttack.Key}: {weapon.FormattedBaseAttack.Value}");
+                        if (weapon.SecondaryStat != null && weapon.SecondaryStat.Type != EnkaDotNet.Enums.Genshin.StatType.None)
+                        {
+                            Console.WriteLine($"      {weapon.FormattedSecondaryStat.Key}: {weapon.FormattedSecondaryStat.Value}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("    No weapon equipped.");
+                    }
+
+                    Console.WriteLine("\n  ARTIFACTS:");
+                    if (character.Artifacts != null && character.Artifacts.Any())
+                    {
+                        foreach (var artifact in character.Artifacts.OrderBy(a => (int)a.Slot))
+                        {
+                            Console.WriteLine($"    {artifact.Name} ({artifact.Slot}) +{artifact.Level}");
+                            Console.WriteLine($"      Set: {artifact.SetName}");
+                            Console.WriteLine($"      Icon: {artifact.IconUrl}");
+                            Console.WriteLine($"      Rarity: {artifact.Rarity}");
+                            Console.WriteLine($"      Main Stat: {artifact.FormattedMainStat.Key}: {artifact.FormattedMainStat.Value}");
+                            Console.WriteLine($"      Substats:");
+                            foreach (var subStat in artifact.FormattedSubStats)
+                            {
+                                Console.WriteLine($"        {subStat.Key}: {subStat.Value}");
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("    No artifacts equipped.");
+                    }
+
+                    Console.WriteLine("\n  TALENTS:");
+                    if (character.Talents != null && character.Talents.Any())
+                    {
+                        foreach (var talent in character.Talents)
+                        {
+                            Console.WriteLine($"    {talent.ToString()}");
+                            Console.WriteLine($"    {talent.IconUrl}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("    Talent data not available.");
+                    }
+
+                    Console.WriteLine("\n  CONSTELLATIONS:");
+                    if (character.Constellations != null && character.Constellations.Any())
+                    {
+                        foreach (var constellation in character.Constellations.OrderBy(c => c.Position))
+                        {
+                            Console.WriteLine($"    {constellation.ToString()}");
+                            Console.WriteLine($"    {constellation.IconUrl}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("    Constellation data not available.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An unexpected error occurred: {ex.Message}");
+                if (ex.InnerException != null) Console.WriteLine($"Inner Error: {ex.InnerException.Message}");
+                Console.WriteLine(ex.StackTrace);
             }
         }
-
-        // Print artifact sets
-        Console.WriteLine("\nArtifact Sets:");
-        var artifactSets = character.Artifacts
-            .GroupBy(a => a.SetName)
-            .Select(g => new { SetName = g.Key, Count = g.Count() })
-            .OrderByDescending(x => x.Count);
-
-        foreach (var set in artifactSets)
-        {
-            Console.WriteLine($"Set: {set.SetName} ({set.Count}pc)");
-        }
-
-        // Print all artifacts
-        Console.WriteLine("\nArtifacts:");
-        foreach (var artifact in character.Artifacts)
-        {
-            Console.WriteLine($"Artifact: {artifact.Name} | Level {artifact.Level} | Rarity {artifact.Rarity} | Set {artifact.SetName}");
-            Console.WriteLine($"Main Stat: {artifact.MainStat?.Type} | {artifact.MainStat?.Value}");
-            Console.WriteLine($"Substats: {string.Join(", ", artifact.SubStats.Select(s => $"{s.Type}: {s.Value}"))}");
-            Console.WriteLine($"Icon: {artifact.IconUrl}");
-        }
-
-        // Print specific stats
-        Console.WriteLine("\nSpecific Stats:");
-        character.GetStatValue(StatType.BaseAttack, out var value);
-        Console.WriteLine($"Base Attack: {value}");
-        character.GetStatValue(StatType.BaseHP, out value);
-        Console.WriteLine($"Base HP: {value}");
-        character.GetStatValue(StatType.BaseDefense, out value);
-        Console.WriteLine($"Base Defense: {value}");
-        character.GetStatValue(StatType.CriticalRate, out value);
-        Console.WriteLine($"Critical Rate: {value}");
-        character.GetStatValue(StatType.CriticalDamage, out value);
-        Console.WriteLine($"Critical Damage: {value}");
-
-        // Constellation data
-        Console.WriteLine("\nConstellations:");
-        foreach (var constellation in character.Constellations)
-        {
-            Console.WriteLine($"Name: {constellation.Name}");
-            Console.WriteLine($"Icon: {constellation.IconUrl}");
-            Console.WriteLine($"Position: {constellation.Position}");
-            Console.WriteLine($"ID: {constellation.Id}");
-        }
-
     }
-}
-catch (Exception ex) when (
-        ex is EnkaDotNet.Exceptions.PlayerNotFoundException ||
-        ex is EnkaDotNet.Exceptions.ProfilePrivateException ||
-        ex is EnkaDotNet.Exceptions.EnkaNetworkException)
-{
-    Console.WriteLine($"Error: {ex.Message}");
 }
 ```
 
@@ -175,7 +184,6 @@ catch (Exception ex) when (
 
 ```csharp
 using EnkaDotNet;
-using EnkaDotNet.Enums;
 
 namespace ZZZStatsViewer
 {
@@ -189,10 +197,11 @@ namespace ZZZStatsViewer
 
                 var options = new EnkaClientOptions
                 {
-                    GameType = GameType.ZZZ,
-                    Language = "en",
+                    GameType = EnkaDotNet.Enums.GameType.ZZZ,
+                    Language = "ja",
                     EnableCaching = true,
                     UserAgent = "EnkaDotNet/5.0",
+                    Raw = false
                 };
 
                 using var client = new EnkaClient(options);
@@ -214,7 +223,6 @@ namespace ZZZStatsViewer
                     return;
                 }
 
-                // Display medals
                 Console.WriteLine("\nMEDALS:");
                 foreach (var medal in playerInfo.Medals)
                 {
@@ -223,116 +231,99 @@ namespace ZZZStatsViewer
                     Console.WriteLine($"Type: {medal.Type}");
                 }
 
-                // Display agent's info
-                var agent = playerInfo.ShowcaseAgents[0];
-                Console.WriteLine($"\nAGENT: {agent.Name} (Lv.{agent.Level})");
-                Console.WriteLine($"Rarity: {agent.Rarity} | Profession: {agent.ProfessionType}");
-                Console.WriteLine($"Elements: {string.Join(", ", agent.ElementTypes)}");
-
-                // Display Mindscapes
-                Console.WriteLine($"Mindscapes: M{agent.TalentLevel}");
-
-                // Display agent's image URL
-                Console.WriteLine($"Image URL: {agent.ImageUrl}");
-                Console.WriteLine($"Circle Icon URL: {agent.CircleIconUrl}");
-                Console.WriteLine($"Promotion Level: {agent.PromotionLevel}");
-
-                // Display agent's obtained timestamp
-                Console.WriteLine($"Obtained Time: {agent.ObtainmentTimestamp.ToLocalTime()}");
-
-                // Display agent's weapon effect state
-                Console.WriteLine($"Weapon Effect State: {agent.WeaponEffectState}");
-
-                // Display agent's stats
-                Console.WriteLine("\nAGENT STATS:");
-                var stats = agent.GetAllStats();
-                foreach (var stat in stats)
+                Console.WriteLine("\nSHOWCASE AGENTS:");
+                foreach (var agent in playerInfo.ShowcaseAgents)
                 {
-                    Console.WriteLine($"{stat.Key}: {stat.Value}");
-                }
+                    Console.WriteLine("\n" + new string('-', 50));
+                    Console.WriteLine($"AGENT: {agent.Name} (Lv.{agent.Level})");
+                    Console.WriteLine($"Rarity: {agent.Rarity} | Profession: {agent.ProfessionType}");
+                    Console.WriteLine($"Elements: {string.Join(", ", agent.ElementTypes)}");
+                    Console.WriteLine($"Mindscapes: M{agent.TalentLevel}");
+                    Console.WriteLine($"Image URL: {agent.ImageUrl}");
+                    Console.WriteLine($"Circle Icon URL: {agent.CircleIconUrl}");
+                    Console.WriteLine($"Promotion Level: {agent.PromotionLevel}");
+                    Console.WriteLine($"Obtained Time: {agent.ObtainmentTimestamp.ToLocalTime()}");
+                    Console.WriteLine($"Weapon Effect State: {agent.WeaponEffectState}");
 
-                // Display weapon
-                if (agent.Weapon != null)
-                {
-                    Console.WriteLine("\nW-ENGINE:");
-                    Console.WriteLine($"Name: {agent.Weapon.Name} (Lv.{agent.Weapon.Level}/{agent.Weapon.BreakLevel})");
-                    Console.WriteLine($"Rarity: {agent.Weapon.Rarity}");
-                    Console.WriteLine($"Main Stat: {agent.Weapon.MainStat}");
-                    Console.WriteLine($"Secondary Stat: {agent.Weapon.SecondaryStat}");
-                    Console.WriteLine($"Effect State: {agent.WeaponEffectState}");
-                    
-                    Console.WriteLine($"Overclock: {agent.Weapon.UpgradeLevel}");
-                    Console.WriteLine($"Icon URL: {agent.Weapon.ImageUrl}");
-                }
-
-                // Display equipped disc sets
-                var discSets = agent.GetEquippedDiscSets();
-                if (discSets.Count > 0)
-                {
-                    Console.WriteLine("\nDRIVE DISC SETS:");
-                    foreach (var set in discSets)
+                    Console.WriteLine("\nAGENT STATS:");
+                    var agentStats = agent.GetAllStats();
+                    foreach (var statPair in agentStats)
                     {
-                        Console.WriteLine($"- {set.SuitName} ({set.PieceCount} pieces)");
-                        foreach (var disc in set.BonusStats)
-                        {
-                            Console.WriteLine($"  - {disc.StatType}: {disc.Value}");
-                        }
+                        Console.WriteLine($"{statPair.Key}: {statPair.Value}");
                     }
-                }
 
-                // Display equipped discs
-                if (agent.EquippedDiscs.Count > 0)
-                {
-                    Console.WriteLine("\nEQUIPPED DISCS:");
-                    foreach (var disc in agent.EquippedDiscs)
+                    if (agent.Weapon != null)
                     {
-                        Console.WriteLine($"- {disc.SuitName} (Lv.{disc.Level})");
-                        Console.WriteLine($"  - Main Stats: {disc.MainStat}");
-                        Console.WriteLine($"  - Rarity: {disc.Rarity}");
-                        Console.WriteLine($"  - Slot: {disc.Slot}");
-                        Console.WriteLine($"  - Icon URL: {disc.IconUrl}");
-                        Console.WriteLine($"  - Locked: {disc.IsLocked}");
-                        Console.WriteLine($"  - Available: {disc.IsAvailable}");
-                        Console.WriteLine($"  - Trash: {disc.IsTrash}");
+                        Console.WriteLine("\nW-ENGINE:");
+                        Console.WriteLine($"Name: {agent.Weapon.Name} (Lv.{agent.Weapon.Level}/{agent.Weapon.BreakLevel})");
+                        Console.WriteLine($"Rarity: {agent.Weapon.Rarity}");
+                        Console.WriteLine($"Main Stat: {agent.Weapon.FormattedMainStat.Key}: {agent.Weapon.FormattedMainStat.Value}");
+                        Console.WriteLine($"Secondary Stat: {agent.Weapon.FormattedSecondaryStat.Key}: {agent.Weapon.FormattedSecondaryStat.Value}");
+                        Console.WriteLine($"Effect State: {agent.WeaponEffectState}");
+                        Console.WriteLine($"Overclock: {agent.Weapon.UpgradeLevel}");
+                        Console.WriteLine($"Icon URL: {agent.Weapon.ImageUrl}");
+                    }
 
-                        foreach (var stat in disc.SubStats)
+                    var discSets = agent.GetEquippedDiscSets();
+                    if (discSets.Count > 0)
+                    {
+                        Console.WriteLine("\nDRIVE DISC SETS:");
+                        foreach (var set in discSets)
                         {
-                            if (stat.IsPercentage)
+                            Console.WriteLine($"- {set.SuitName} ({set.PieceCount} pieces)");
+                            foreach (var bonus in set.BonusStats)
                             {
-                                Console.WriteLine($"  - {stat.Type}: {stat.Value * stat.Level:F1}% +{stat.Level}");
-                            }
-                            else
-                            {
-                                Console.WriteLine($"  - {stat.Type}: {(int)stat.Value * stat.Level} +{stat.Level}");
+                                Console.WriteLine($"  - {bonus.Key}: {bonus.Value}");
                             }
                         }
                     }
-                }
 
-                // Display core skills
-                if (agent.CoreSkillEnhancements.Count > 0)
-                {
-                    Console.WriteLine("\nCORE SKILLS:");
-                    foreach (var skill in agent.CoreSkillEnhancements)
+                    if (agent.EquippedDiscs.Count > 0)
                     {
-                        if (agent.CoreSkillEnhancements.Count > 0)
+                        Console.WriteLine("\nEQUIPPED DISCS:");
+                        foreach (var disc in agent.EquippedDiscs)
                         {
-                            char skillLetter = (char)('A' + skill);
-                            Console.WriteLine($"- {skillLetter} ({skill})");
+                            Console.WriteLine($"- {disc.SuitName} (Lv.{disc.Level})");
+                            Console.WriteLine($"  - Main Stats: {disc.FormattedMainStat.Key}: {disc.FormattedMainStat.Value}");
+                            Console.WriteLine($"  - Rarity: {disc.Rarity}");
+                            Console.WriteLine($"  - Slot: {disc.Slot}");
+                            Console.WriteLine($"  - Icon URL: {disc.IconUrl}");
+                            Console.WriteLine($"  - Locked: {disc.IsLocked}");
+                            Console.WriteLine($"  - Available: {disc.IsAvailable}");
+                            Console.WriteLine($"  - Trash: {disc.IsTrash}");
+
+                            foreach (var statPair in disc.SubStats)
+                            {
+                                Console.WriteLine($"  - {statPair.Key}: {statPair.Value}");
+                            }
                         }
                     }
-                }
 
-                // Display skill levels
-                Console.WriteLine("\nSKILL LEVELS:");
-                foreach (var skill in agent.SkillLevels)
-                {
-                    Console.WriteLine($"- {skill.Key}: {skill.Value}");
+                    if (agent.CoreSkillEnhancements.Count > 0)
+                    {
+                        Console.WriteLine("\nCORE SKILLS:");
+                        foreach (var skill in agent.CoreSkillEnhancements)
+                        {
+                            if (agent.CoreSkillEnhancements.Count > 0)
+                            {
+                                char skillLetter = (char)('A' + skill);
+                                Console.WriteLine($"- {skillLetter} ({skill})");
+                            }
+                        }
+                    }
+
+                    Console.WriteLine("\nSKILL LEVELS:");
+                    foreach (var skill in agent.SkillLevels)
+                    {
+                        Console.WriteLine($"- {skill.Key}: {skill.Value}");
+                    }
                 }
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error: {ex.Message}");
+                if (ex.InnerException != null) Console.WriteLine($"Inner Error: {ex.InnerException.Message}");
+                Console.WriteLine(ex.StackTrace);
             }
         }
     }
@@ -343,7 +334,6 @@ namespace ZZZStatsViewer
 
 ```csharp
 using EnkaDotNet;
-using EnkaDotNet.Enums;
 using EnkaDotNet.Enums.HSR;
 using EnkaDotNet.Components.HSR;
 using EnkaDotNet.Utils.HSR;
@@ -360,10 +350,11 @@ namespace HSRStatsViewer
 
                 var options = new EnkaClientOptions
                 {
-                    GameType = GameType.HSR,
-                    Language = "en",
+                    GameType = EnkaDotNet.Enums.GameType.HSR,
+                    Language = "ja",
                     EnableCaching = true,
                     UserAgent = "EnkaDotNet/5.0",
+                    Raw = false,
                 };
 
                 using var client = new EnkaClient(options);
@@ -378,7 +369,6 @@ namespace HSRStatsViewer
                 Console.WriteLine($"Platform: {playerInfo.Platform}");
                 Console.WriteLine($"Player Icon: {playerInfo.ProfilePictureIcon}");
 
-                // Display record info
                 Console.WriteLine("\nRECORD INFO:");
                 Console.WriteLine($"Achievements: {playerInfo.RecordInfo.AchievementCount}");
                 Console.WriteLine($"Characters: {playerInfo.RecordInfo.AvatarCount}");
@@ -392,106 +382,103 @@ namespace HSRStatsViewer
                     return;
                 }
 
-                // Display character info for first character
-                var character = playerInfo.DisplayedCharacters[6];
-                Console.WriteLine($"\nCHARACTER INFO:");
-                Console.WriteLine($"Name: {character.Name} (Lv.{character.Level}/{character.Promotion})");
-                Console.WriteLine($"Rarity: {character.Rarity} | Path: {character.Path.GetPathName()}");
-                Console.WriteLine($"Element: {character.Element}");
-                Console.WriteLine($"Rank: {character.Rank} | Position: {character.Position}");
-                Console.WriteLine($"Icon URL: {character.IconUrl}");
-                Console.WriteLine($"Avatar Icon URL: {character.AvatarIconUrl}");
-
-                // Display character stats
-                Console.WriteLine("\nSTATS:");
-                foreach (var stat in character.Stats)
+                Console.WriteLine("\nDISPLAYED CHARACTERS:");
+                foreach (var character in playerInfo.DisplayedCharacters)
                 {
-                    Console.WriteLine($"{stat.Key}: {stat.Value}");
-                }
+                    Console.WriteLine("\n" + new string('=', 60));
+                    Console.WriteLine($"CHARACTER INFO:");
+                    Console.WriteLine($"Name: {character.Name} (Lv.{character.Level}/{character.Promotion})");
+                    Console.WriteLine($"Rarity: {character.Rarity} | Path: {character.Path.GetPathName()}");
+                    Console.WriteLine($"Element: {character.Element}");
+                    Console.WriteLine($"Rank: {character.Rank} | Position: {character.Position}");
+                    Console.WriteLine($"Icon URL: {character.IconUrl}");
+                    Console.WriteLine($"Avatar Icon URL: {character.AvatarIconUrl}");
 
-                // Display light cone
-                if (character.Equipment != null)
-                {
-                    var lightCone = character.Equipment;
-                    Console.WriteLine("\nLIGHT CONE:");
-                    Console.WriteLine($"Name: {lightCone.Name} (Lv.{lightCone.Level}/{lightCone.Promotion})");
-                    Console.WriteLine($"Rarity: {lightCone.Rarity} | Path: {lightCone.Path}");
-                    Console.WriteLine($"Superimposition: {lightCone.Rank}");
-                    Console.WriteLine($"Base HP: {lightCone.BaseHP:F0}");
-                    Console.WriteLine($"Base ATK: {lightCone.BaseAttack:F0}");
-                    Console.WriteLine($"Base DEF: {lightCone.BaseDefense:F0}");
-                    Console.WriteLine($"Icon URL: {lightCone.IconUrl}");
-                }
-
-                // Display eidolons
-                Console.WriteLine("\nEIDOLONS:");
-                foreach (var eidolon in character.Eidolons)
-                {
-                    Console.WriteLine($"- Id: {eidolon.Id}");
-                    Console.WriteLine($"- Icon URL: {eidolon.Icon}");
-                    Console.WriteLine($"- Unlocked: {eidolon.Unlocked}");
-                }
-
-                // Display relics
-                if (character.RelicList.Count > 0)
-                {
-                    Console.WriteLine("\nRELICS:");
-                    foreach (var relic in character.RelicList)
+                    Console.WriteLine("\nSTATS:");
+                    foreach (var stat in character.GetAllStats())
                     {
-                        Console.WriteLine($"- {relic.SetName} ({relic.RelicType.GetRelicName()}) - Lv.{relic.Level}");
-                        Console.WriteLine($"  Rarity: {relic.Rarity}");
-                        Console.WriteLine($"  Main Stat: {relic.MainStat}");
-                        Console.WriteLine($"  Icon URL: {relic.IconUrl}");
+                        Console.WriteLine($"{stat.Key}: {stat.Value}");
+                    }
 
-                        Console.WriteLine("  Sub Stats:");
-                        foreach (var subStat in relic.SubStats)
+                    if (character.Equipment != null)
+                    {
+                        var lightCone = character.Equipment;
+                        Console.WriteLine("\nLIGHT CONE:");
+                        Console.WriteLine($"Name: {lightCone.Name} (Lv.{lightCone.Level}/{lightCone.Promotion})");
+                        Console.WriteLine($"Rarity: {lightCone.Rarity} | Path: {lightCone.Path}");
+                        Console.WriteLine($"Superimposition: {lightCone.Rank}");
+                        Console.WriteLine($"Base HP: {lightCone.BaseHP:F0}");
+                        Console.WriteLine($"Base ATK: {lightCone.BaseAttack:F0}");
+                        Console.WriteLine($"Base DEF: {lightCone.BaseDefense:F0}");
+                        Console.WriteLine($"Icon URL: {lightCone.IconUrl}");
+                    }
+
+                    Console.WriteLine("\nEIDOLONS:");
+                    foreach (var eidolon in character.Eidolons)
+                    {
+                        Console.WriteLine($"- Id: {eidolon.Id}");
+                        Console.WriteLine($"- Icon URL: {eidolon.Icon}");
+                        Console.WriteLine($"- Unlocked: {eidolon.Unlocked}");
+                    }
+
+                    if (character.RelicList.Count > 0)
+                    {
+                        Console.WriteLine("\nRELICS:");
+                        foreach (var relic in character.RelicList)
                         {
-                            Console.WriteLine($"  - {HSRStatPropertyUtils.GetDisplayName(subStat.Type)}: {subStat.DisplayValue}");
+                            Console.WriteLine($"- {relic.SetName} ({relic.RelicType.GetRelicName()}) - Lv.{relic.Level}");
+                            Console.WriteLine($"  Rarity: {relic.Rarity}");
+                            Console.WriteLine($"  Main Stat: {relic.MainStat}");
+                            Console.WriteLine($"  Icon URL: {relic.IconUrl}");
+
+                            Console.WriteLine("  Sub Stats:");
+                            foreach (var subStat in relic.SubStats)
+                            {
+                                Console.WriteLine($"  - {HSRStatPropertyUtils.GetDisplayName(subStat.Type)}: {subStat.DisplayValue}");
+                            }
                         }
                     }
-                }
 
-                // Display relic sets
-                var relicSets = character.GetEquippedRelicSets();
-                if (relicSets.Count > 0)
-                {
-                    Console.WriteLine("\nRELIC SET BONUSES:");
-                    foreach (var setBonus in relicSets)
+                    var relicSets = character.GetEquippedRelicSets();
+                    if (relicSets.Count > 0)
                     {
-                        Console.WriteLine($"    - {setBonus.SetName} ({setBonus.PieceCount}pcs)");
-                        foreach (var effectDetail in setBonus.Effects)
+                        Console.WriteLine("\nRELIC SET BONUSES:");
+                        foreach (var setBonus in relicSets)
                         {
-                            Console.WriteLine($"      - {effectDetail.PropertyName}: +{effectDetail.FormattedValue}");
+                            Console.WriteLine($"    - {setBonus.SetName} ({setBonus.PieceCount}pcs)");
+                            foreach (var effectDetail in setBonus.Effects)
+                            {
+                                Console.WriteLine($"      - {effectDetail.PropertyName}: +{effectDetail.FormattedValue}");
+                            }
                         }
                     }
-                }
 
-                // Display skill trees
-                Console.WriteLine("\nSKILL TREES:");
-                if (character.SkillTreeList != null && character.SkillTreeList.Count > 0)
-                {
-                    foreach (HSRSkillTree trace in character.SkillTreeList)
+                    Console.WriteLine("\nSKILL TREES:");
+                    if (character.SkillTreeList != null && character.SkillTreeList.Count > 0)
                     {
-                        Console.WriteLine($"Type: {trace.TraceType}");
-                        Console.WriteLine($"Icon URL: {trace.Icon}");
-                        Console.WriteLine($"Anchor: {trace.Anchor}");
+                        foreach (HSRSkillTree trace in character.SkillTreeList)
+                        {
+                            Console.WriteLine($"Type: {trace.TraceType}");
+                            Console.WriteLine($"Icon URL: {trace.Icon}");
+                            Console.WriteLine($"Anchor: {trace.Anchor}");
 
-                        string levelDisplay;
-                        if (trace.IsBoosted)
-                        {
-                            levelDisplay = $"{trace.BaseLevel} + {trace.Level - trace.BaseLevel} = {trace.Level}";
+                            string levelDisplay;
+                            if (trace.IsBoosted)
+                            {
+                                levelDisplay = $"{trace.BaseLevel} + {trace.Level - trace.BaseLevel} = {trace.Level}";
+                            }
+                            else
+                            {
+                                levelDisplay = $"{trace.Level}";
+                            }
+                            Console.WriteLine($"Level: {levelDisplay} / {trace.MaxLevel}");
+                            Console.WriteLine($"Boosted by Eidolon: {trace.IsBoosted}");
                         }
-                        else
-                        {
-                            levelDisplay = $"{trace.Level}";
-                        }
-                        Console.WriteLine($"Level: {levelDisplay} / {trace.MaxLevel}");
-                        Console.WriteLine($"Boosted by Eidolon: {trace.IsBoosted}");
                     }
-                }
-                else
-                {
-                    Console.WriteLine($"{character.Name} has no skill tree information available.");
+                    else
+                    {
+                        Console.WriteLine($"{character.Name} has no skill tree information available.");
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
This commit introduces a new `Options` property of type `EnkaClientOptions` across various classes to manage user preferences for displaying raw or formatted stats. Several methods have been updated to utilize this property, enhancing the flexibility of stat formatting.

New utility methods in `GenshinStatUtils` facilitate the display and formatting of stats. The `GetAllStats` methods have been modified to return formatted stats, improving readability.

Additionally, the README.md has been updated to include new features and usage examples for Genshin Impact, Honkai: Star Rail, and Zenless Zone Zero. The project file now supports multiple target frameworks, broadening compatibility.

These changes significantly enhance the usability and functionality of the EnkaDotNet library for developers working with Hoyoverse character data.