### PR TITLE
Update disclaimer with additional trademarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,4 +516,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Disclaimer
 
-This project is not affiliated with or endorsed by HoYoverse (miHoYo) or Enka.Network. Genshin Impact is a trademark of HoYoverse.
+This project is not affiliated with or endorsed by HoYoverse (miHoYo) or Enka.Network. Genshin Impact, Honkai: Star Rail, and Zenless Zone Zero are trademarks of HoYoverse.


### PR DESCRIPTION
The disclaimer has been revised to include "Honkai: Star Rail" and "Zenless Zone Zero" as trademarks of HoYoverse, while maintaining the original statement regarding affiliation.