### PR TITLE
Add avatar color retrieval functionality

### DIFF
--- a/EnkaDotNet/Assets/ZZZ/IZZZAssets.cs
+++ b/EnkaDotNet/Assets/ZZZ/IZZZAssets.cs
@@ -42,5 +42,7 @@ namespace EnkaDotNet.Assets.ZZZ
         List<ZZZEquipmentLevelItem> GetEquipmentLevelData();
         List<ZZZWeaponLevelItem> GetWeaponLevelData();
         List<ZZZWeaponStarItem> GetWeaponStarData();
+
+        List<ZZZAvatarColors> GetAvatarColors(int agentId);
     }
 }

--- a/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
+++ b/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
@@ -318,13 +318,23 @@ namespace EnkaDotNet.Assets.ZZZ
         public ZZZAvatarAssetInfo GetAvatarInfo(string agentId)
         {
             _avatars.TryGetValue(agentId, out var avatarInfo);
-            return avatarInfo; // Returns null if not found
+            return avatarInfo; 
         }
 
         public ZZZWeaponAssetInfo GetWeaponInfo(string weaponId)
         {
             _weapons.TryGetValue(weaponId, out var weaponInfo);
-            return weaponInfo; // Returns null if not found
+            return weaponInfo;
+        }
+
+        public List<ZZZAvatarColors> GetAvatarColors(int agentId)
+        {
+            string agentIdStr = agentId.ToString();
+            if (_avatars.TryGetValue(agentIdStr, out var avatarInfo) && avatarInfo.Colors != null)
+            {
+                return new List<ZZZAvatarColors> { avatarInfo.Colors };
+            }
+            return new List<ZZZAvatarColors>();
         }
 
         public string GetAgentName(int agentId)

--- a/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
@@ -39,6 +39,8 @@ namespace EnkaDotNet.Components.ZZZ
         public string ImageUrl { get; internal set; } = string.Empty;
         public string CircleIconUrl { get; internal set; } = string.Empty;
 
+        public List<ZZZAvatarColors> Colors { get; internal set; } = new List<ZZZAvatarColors>();
+
         public Dictionary<StatType, double> Stats { get; internal set; } = new Dictionary<StatType, double>();
 
         internal EnkaClientOptions Options { get; set; }

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.3.1</Version>
+       <Version>1.3.2</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/EnkaDotNet/Utils/ZZZ/ZZZDataMapper.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZDataMapper.cs
@@ -9,6 +9,7 @@ using EnkaDotNet.Models.ZZZ;
 using EnkaDotNet.Components.ZZZ;
 using EnkaDotNet.Assets.ZZZ;
 using EnkaDotNet.Enums.ZZZ;
+using EnkaDotNet.Assets.ZZZ.Models;
 
 namespace EnkaDotNet.Utils.ZZZ
 {
@@ -111,6 +112,7 @@ namespace EnkaDotNet.Utils.ZZZ
                 Rarity = (Rarity)_assets.GetAgentRarity(model.Id),
                 ProfessionType = _assets.GetAgentProfessionType(model.Id),
                 ElementTypes = FilterUnknownElements(_assets.GetAgentElements(model.Id)),
+                Colors = _assets.GetAvatarColors(model.Id),
                 Options = this._options,
                 Assets = this._assets
             };
@@ -220,6 +222,12 @@ namespace EnkaDotNet.Utils.ZZZ
             if (elements == null || elements.Count == 0) return new List<ElementType> { ElementType.Unknown };
             var validElements = elements.Where(e => e != ElementType.Unknown).Distinct().ToList();
             return validElements.Count > 0 ? validElements : elements;
+        }
+
+        private List<ZZZAvatarColors> GetAgentColor(int agentId)
+        {
+            var colors = _assets.GetAvatarColors(agentId);
+            return colors ?? new List<ZZZAvatarColors>();
         }
     }
 }


### PR DESCRIPTION
- Introduced `GetAvatarColors(int agentId)` method in `IZZZAssets` and implemented it in `ZZZAssets`.
- Updated `GetAvatarInfo` and `GetWeaponInfo` methods to return values directly.
- Added `Colors` property to `ZZZAgent` class for storing avatar colors.
- Enhanced `ZZZDataMapper` to retrieve avatar colors and added a private method for encapsulation.
- Bumped project version from `1.3.1` to `1.3.2`.
- Included new using directive for `EnkaDotNet.Assets.ZZZ.Models`.