### PR TITLE
Refactor relic data handling and update stats calculations

### DIFF
--- a/EnkaDotNet/Assets/HSR/HSRAssets.cs
+++ b/EnkaDotNet/Assets/HSR/HSRAssets.cs
@@ -180,26 +180,24 @@ namespace EnkaDotNet.Assets.HSR
             _relicSets.Clear();
             try
             {
-                var relicData = await FetchAndDeserializeAssetAsync<HSRRelicData>("relics.json");
+                var relicItemsMap = await FetchAndDeserializeAssetAsync<Dictionary<string, HSRRelicItemInfo>>("relics.json");
+                foreach (var kvp in relicItemsMap)
+                {
+                    _relicItems[kvp.Key] = kvp.Value;
 
-                if (relicData?.Items != null)
-                {
-                    foreach (var kvp in relicData.Items)
+                    string setId = kvp.Value.SetID.ToString();
+                    if (!_relicSets.ContainsKey(setId))
                     {
-                        _relicItems[kvp.Key] = kvp.Value;
-                    }
-                }
-                if (relicData?.Sets != null)
-                {
-                    foreach (var kvp in relicData.Sets)
-                    {
-                        _relicSets[kvp.Key] = kvp.Value;
+                        _relicSets[setId] = new HSRRelicSetInfo
+                        {
+                            SetName = kvp.Value.SetID.ToString()
+                        };
                     }
                 }
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Failed to load essential relics data", ex);
+                throw new InvalidOperationException($"Failed to load essential relics data", ex);
             }
         }
 

--- a/EnkaDotNet/Assets/HSR/Models/HSRRelicAssetInfo.cs
+++ b/EnkaDotNet/Assets/HSR/Models/HSRRelicAssetInfo.cs
@@ -9,15 +9,6 @@ using Newtonsoft.Json;
 
 namespace EnkaDotNet.Assets.HSR.Models
 {
-    public class HSRRelicData
-    {
-        [JsonProperty("Items")]
-        public Dictionary<string, HSRRelicItemInfo> Items { get; set; }
-
-        [JsonProperty("Sets")]
-        public Dictionary<string, HSRRelicSetInfo> Sets { get; set; }
-    }
-
     public class HSRRelicItemInfo
     {
         [JsonProperty("Icon")]

--- a/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZAgent.cs
@@ -46,47 +46,132 @@ namespace EnkaDotNet.Components.ZZZ
         internal EnkaClientOptions Options { get; set; }
         internal IZZZAssets Assets { get; set; }
 
-        public Dictionary<string, string> GetAllStats()
+        public Dictionary<string, FormattedStatValues> GetAllStats()
         {
             bool raw = this.Options?.Raw ?? false;
-            var resultStats = new Dictionary<string, string>();
+            var resultStats = new Dictionary<string, FormattedStatValues>();
             var calculatedStats = ZZZStatsHelpers.CalculateAllTotalStats(this);
 
             foreach (var statPair in calculatedStats)
             {
                 string friendlyKey = statPair.Key;
-                double numericValue = statPair.Value;
+                double numericValue = statPair.Value.FinalValue;
+                double baseValue = statPair.Value.BaseValue;
+                double addedValue = statPair.Value.AddedValue;
                 bool isPercentage = ZZZStatsHelpers.IsDisplayPercentageStatForGroup(friendlyKey);
                 bool isEnergyRegen = friendlyKey == "Energy Regen";
                 StatType statType = ZZZStatsHelpers.GetStatTypeFromFriendlyName(friendlyKey, isPercentage, isEnergyRegen);
 
                 string displayKey;
                 string displayValue;
+                string displayBase;
+                string displayAdded;
 
                 if (raw)
                 {
                     displayKey = statType.ToString();
                     if (isEnergyRegen)
                     {
-                        string formatted = numericValue.ToString("F2", CultureInfo.InvariantCulture);
-                        displayValue = formatted.EndsWith("0") ? formatted.TrimEnd('0') : formatted;
+                        if (Math.Abs(numericValue) < 0.01)
+                        {
+                            displayValue = "0";
+                        }
+                        else
+                        {
+                            string formatted = numericValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayValue = formatted.EndsWith("0") ? formatted.TrimEnd('0') : formatted;
+                        }
+
+                        if (Math.Abs(baseValue) < 0.01)
+                        {
+                            displayBase = "0";
+                        }
+                        else
+                        {
+                            string formattedBase = baseValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayBase = formattedBase.EndsWith("0") ? formattedBase.TrimEnd('0') : formattedBase;
+                        }
+
+                        if (Math.Abs(addedValue) < 0.01)
+                        {
+                            displayAdded = "0";
+                        }
+                        else
+                        {
+                            string formattedAdded = addedValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayAdded = formattedAdded.EndsWith("0") ? formattedAdded.TrimEnd('0') : formattedAdded;
+                        }
                     }
-                    else if (isPercentage) displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture);
-                    else displayValue = Math.Floor(numericValue).ToString();
+                    else if (isPercentage)
+                    {
+                        displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture);
+                        displayBase = baseValue.ToString("F2", CultureInfo.InvariantCulture);
+                        displayAdded = addedValue.ToString("F2", CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        displayValue = Math.Floor(numericValue).ToString();
+                        displayBase = Math.Floor(baseValue).ToString();
+                        displayAdded = Math.Floor(addedValue).ToString();
+                    }
                 }
                 else
                 {
                     displayKey = friendlyKey;
                     if (isEnergyRegen)
                     {
-                        string formatted = numericValue.ToString("F2", CultureInfo.InvariantCulture);
-                        displayValue = formatted.EndsWith("0") ? formatted.TrimEnd('0') : formatted;
+                        if (Math.Abs(numericValue) < 0.01)
+                        {
+                            displayValue = "0";
+                        }
+                        else
+                        {
+                            string formatted = numericValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayValue = formatted.EndsWith("0") ? formatted.TrimEnd('0') : formatted;
+                        }
+
+                        if (Math.Abs(baseValue) < 0.01)
+                        {
+                            displayBase = "0";
+                        }
+                        else
+                        {
+                            string formattedBase = baseValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayBase = formattedBase.EndsWith("0") ? formattedBase.TrimEnd('0') : formattedBase;
+                        }
+
+                        if (Math.Abs(addedValue) < 0.01)
+                        {
+                            displayAdded = "0";
+                        }
+                        else
+                        {
+                            string formattedAdded = addedValue.ToString("F2", CultureInfo.InvariantCulture);
+                            displayAdded = formattedAdded.EndsWith("0") ? formattedAdded.TrimEnd('0') : formattedAdded;
+                        }
                     }
-                    else if (isPercentage) displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture) + "%";
-                    else displayValue = Math.Floor(numericValue).ToString();
+                    else if (isPercentage)
+                    {
+                        displayValue = numericValue.ToString("F1", CultureInfo.InvariantCulture) + "%";
+                        displayBase = baseValue.ToString("F1", CultureInfo.InvariantCulture) + "%";
+                        displayAdded = addedValue.ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    }
+                    else
+                    {
+                        displayValue = Math.Floor(numericValue).ToString();
+                        displayBase = Math.Floor(baseValue).ToString();
+                        displayAdded = Math.Floor(addedValue).ToString();
+                    }
                 }
-                resultStats[displayKey] = displayValue;
+
+                resultStats[displayKey] = new FormattedStatValues
+                {
+                    Final = displayValue,
+                    Base = displayBase,
+                    Added = displayAdded
+                };
             }
+
             return resultStats;
         }
 

--- a/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZDriveDisc.cs
@@ -62,7 +62,7 @@ namespace EnkaDotNet.Components.ZZZ
                     else if (stat.IsEnergyRegen && !raw) value = (totalValue / 100).ToString("F1", CultureInfo.InvariantCulture) + "%";
                     else if (stat.IsEnergyRegen && raw) value = (totalValue / 100).ToString("F1", CultureInfo.InvariantCulture);
                     else value = Math.Floor(totalValue).ToString();
-                    formattedList.Add(new KeyValuePair<string, string>(key, $"{value} +{stat.Level}"));
+                    formattedList.Add(new KeyValuePair<string, string>(key, value));
                 }
                 return formattedList;
             }

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.3.3</Version>
+       <Version>1.3.4</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/EnkaDotNet/Enums/HSR/HSREnums.cs
+++ b/EnkaDotNet/Enums/HSR/HSREnums.cs
@@ -56,47 +56,49 @@ namespace EnkaDotNet.Enums.HSR
 
     public enum StatPropertyType
     {
-        None = 0,
+        None,
 
         // Base Stats
-        HPDelta = 1,
-        HPAddedRatio = 2,
-        AttackDelta = 3,
-        AttackAddedRatio = 4,
-        DefenceDelta = 5,
-        DefenceAddedRatio = 6,
-        SpeedDelta = 7,
+        HPDelta,
+        HPAddedRatio,
+        AttackDelta,
+        AttackAddedRatio,
+        DefenceDelta,
+        DefenceAddedRatio,
+        SpeedDelta,
 
         // Critical Stats
-        CriticalChance = 8,
-        CriticalDamage = 9,
+        CriticalChance,
+        CriticalDamage,
 
         // Effect Stats
-        StatusProbability = 10,
-        StatusResistance = 11,
-        BreakDamageAddedRatio = 12,
+        StatusProbability,
+        StatusResistance,
+        BreakDamageAddedRatio,
 
         // Base properties
-        BaseHP = 1001,
-        BaseAttack = 1002,
-        BaseDefence = 1003,
-        BaseSpeed = 1004,
+        BaseHP,
+        BaseAttack,
+        BaseDefence,
+        BaseSpeed,
 
         // Elemental DMG
-        PhysicalAddedRatio = 2001,
-        FireAddedRatio = 2002,
-        IceAddedRatio = 2003,
-        LightningAddedRatio = 2004,
-        WindAddedRatio = 2005,
-        QuantumAddedRatio = 2006,
-        ImaginaryAddedRatio = 2007,
+        PhysicalAddedRatio,
+        FireAddedRatio,
+        IceAddedRatio,
+        LightningAddedRatio,
+        WindAddedRatio,
+        QuantumAddedRatio,
+        ImaginaryAddedRatio,
 
         // Special stats
-        HealRatioBase = 3001,
-        SPRatioBase = 3002,
-        CriticalChanceBase = 3003,
-        CriticalDamageBase = 3004,
-        BreakDamageAddedRatioBase = 3005
+        HealRatioBase,
+        SPRatioBase,
+        CriticalChanceBase,
+        CriticalDamageBase,
+        BreakDamageAddedRatioBase,
+        SpeedAddedRatio,
+        StatusResistanceBase
     }
 
     public enum Rarity

--- a/EnkaDotNet/Enums/ZZZ/StatSummary.cs
+++ b/EnkaDotNet/Enums/ZZZ/StatSummary.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EnkaDotNet.Enums.ZZZ
+{
+    public class StatSummary
+    {
+        public double FinalValue { get; set; }
+        public double BaseValue { get; set; }
+        public double AddedValue { get; set; }
+    }
+
+    public class FormattedStatValues
+    {
+        public string Final { get; set; }
+        public string Base { get; set; }
+        public string Added { get; set; }
+
+        public static implicit operator string(FormattedStatValues value)
+        {
+            return value.Final;
+        }
+
+        public override string ToString()
+        {
+            return Final;
+        }
+    }
+}

--- a/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
+++ b/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
@@ -10,8 +10,7 @@ namespace EnkaDotNet.Enums.ZZZ
 {
     public enum WEngineEffectState
     {
-        None = 0,
-        Off = 1,
-        On = 2 
+        Off = 0,
+        On = 1 
     }
 }

--- a/EnkaDotNet/Utils/HSR/HSRStatPropertyUtils.cs
+++ b/EnkaDotNet/Utils/HSR/HSRStatPropertyUtils.cs
@@ -45,6 +45,8 @@ namespace EnkaDotNet.Utils.HSR
             { "CriticalDamage", true },
             { "StatusProbability", true },
             { "StatusResistance", true },
+            { "StatusResistanceBase", true },
+            { "SpeedAddedRatio", true },
             { "BreakDamageAddedRatio", true },
             { "SPRatioBase", true },
             { "HealRatioBase", true },
@@ -124,6 +126,8 @@ namespace EnkaDotNet.Utils.HSR
             PropertyTypeToDisplayName["DefenceDelta"] = "DEF";
             PropertyTypeToDisplayName["DefenceAddedRatio"] = "DEF%";
             PropertyTypeToDisplayName["SpeedDelta"] = "SPD";
+            PropertyTypeToDisplayName["StatusResistanceBase"] = "Effect RES";
+            PropertyTypeToDisplayName["SpeedAddedRatio"] = "SPD";
 
 
             PropertyTypeToDisplayName["BaseHP"] = "Base HP";

--- a/EnkaDotNet/Utils/HSR/HSRStatsCalculator.cs
+++ b/EnkaDotNet/Utils/HSR/HSRStatsCalculator.cs
@@ -259,40 +259,48 @@ namespace EnkaDotNet.Utils.HSR
             double baseSpd = stats.ContainsKey("SpeedBase") ? stats["SpeedBase"] : 0;
             double spdDelta = stats.ContainsKey("SpeedDelta") ? stats["SpeedDelta"] : 0;
             double spdAddedRatio = stats.ContainsKey("SpeedAddedRatio") ? stats["SpeedAddedRatio"] : 0;
-            double finalSPD = Math.Round((baseSpd * (1.0 + spdAddedRatio) + spdDelta), 1);
+            double rawSpeed = (baseSpd * (1.0 + spdAddedRatio) + spdDelta);
+            double finalSPD = Math.Floor(rawSpeed * 10) / 10;
             finalStats["Speed"] = new HSRStatValue(finalSPD, _options, false, 1);
 
             double criticalChance = stats.ContainsKey("CriticalChance") ? stats["CriticalChance"] : 0;
             double criticalChanceBase = stats.ContainsKey("CriticalChanceBase") ? stats["CriticalChanceBase"] : 0;
-            double finalCritRate = Math.Round((criticalChance + criticalChanceBase) * 100.0, 1);
+            double rawCritRate = (criticalChance + criticalChanceBase) * 100.0;
+            double finalCritRate = Math.Floor(rawCritRate * 10) / 10;
             finalStats["CritRate"] = new HSRStatValue(finalCritRate, _options, true, 1);
 
             double criticalDamage = stats.ContainsKey("CriticalDamage") ? stats["CriticalDamage"] : 0;
             double criticalDamageBase = stats.ContainsKey("CriticalDamageBase") ? stats["CriticalDamageBase"] : 0;
-            double finalCritDMG = Math.Round((criticalDamage + criticalDamageBase) * 100.0, 1);
+            double rawCritDMG = (criticalDamage + criticalDamageBase) * 100.0;
+            double finalCritDMG = Math.Floor(rawCritDMG * 10) / 10;
             finalStats["CritDMG"] = new HSRStatValue(finalCritDMG, _options, true, 1);
 
             double breakDamage = stats.ContainsKey("BreakDamageAddedRatio") ? stats["BreakDamageAddedRatio"] : 0;
             double breakDamageBase = stats.ContainsKey("BreakDamageAddedRatioBase") ? stats["BreakDamageAddedRatioBase"] : 0;
-            double finalBreakEffect = Math.Round((breakDamage + breakDamageBase) * 100.0, 1);
+            double rawValue = (breakDamage + breakDamageBase) * 100.0;
+            double finalBreakEffect = Math.Floor(rawValue * 10) / 10;
             finalStats["BreakEffect"] = new HSRStatValue(finalBreakEffect, _options, true, 1);
 
             double healRatio = stats.ContainsKey("HealRatioBase") ? stats["HealRatioBase"] : 0;
-            double finalHealingBoost = Math.Round(healRatio * 100.0, 1);
+            double rawHealingBoost = healRatio * 100.0;
+            double finalHealingBoost = Math.Floor(rawHealingBoost * 10) / 10;
             finalStats["HealingBoost"] = new HSRStatValue(finalHealingBoost, _options, true, 1);
 
             double spRatio = stats.ContainsKey("SPRatioBase") ? stats["SPRatioBase"] : 0;
-            double finalEnergyRegenRate = Math.Round((1.0 + spRatio) * 100.0, 1);
+            double rawEnergyRegenRate = (1.0 + spRatio) * 100.0;
+            double finalEnergyRegenRate = Math.Floor(rawEnergyRegenRate * 10) / 10;
             finalStats["EnergyRegenRate"] = new HSRStatValue(finalEnergyRegenRate, _options, true, 1);
 
             double statusProbability = stats.ContainsKey("StatusProbability") ? stats["StatusProbability"] : 0;
             double statusProbabilityBase = stats.ContainsKey("StatusProbabilityBase") ? stats["StatusProbabilityBase"] : 0;
-            double finalEffectHitRate = Math.Round((statusProbability + statusProbabilityBase) * 100.0, 1);
+            double rawEffectHitRate = (statusProbability + statusProbabilityBase) * 100.0;
+            double finalEffectHitRate = Math.Floor(rawEffectHitRate * 10) / 10;
             finalStats["EffectHitRate"] = new HSRStatValue(finalEffectHitRate, _options, true, 1);
 
             double statusResistance = stats.ContainsKey("StatusResistance") ? stats["StatusResistance"] : 0;
             double statusResistanceBase = stats.ContainsKey("StatusResistanceBase") ? stats["StatusResistanceBase"] : 0;
-            double finalEffectResistance = Math.Round((statusResistance + statusResistanceBase) * 100.0, 1);
+            double rawEffectResistance = (statusResistance + statusResistanceBase) * 100.0;
+            double finalEffectResistance = Math.Floor(rawEffectResistance * 10) / 10;
             finalStats["EffectResistance"] = new HSRStatValue(finalEffectResistance, _options, true, 1);
 
             Dictionary<string, string> elementMapping = new Dictionary<string, string>
@@ -310,8 +318,9 @@ namespace EnkaDotNet.Utils.HSR
             {
                 string propName = $"{elem.Key}AddedRatio";
                 double valueDecimal = stats.ContainsKey(propName) ? stats[propName] : 0;
-                double valuePercent = Math.Round(valueDecimal * 100.0, 1);
-                finalStats[elem.Value] = new HSRStatValue(valuePercent, _options, true, 1);
+                double valuePercent = valueDecimal * 100.0;
+                double finalValue = Math.Floor(valuePercent * 10) / 10;
+                finalStats[elem.Value] = new HSRStatValue(finalValue, _options, true, 1);
             }
 
             return finalStats;

--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ namespace ZZZStatsViewer
                 var options = new EnkaClientOptions
                 {
                     GameType = EnkaDotNet.Enums.GameType.ZZZ,
-                    Language = "ja",
+                    Language = "en",
                     EnableCaching = true,
                     UserAgent = "EnkaDotNet/5.0",
-                    Raw = false
+                    Raw = false,
                 };
 
                 using var client = new EnkaClient(options);
@@ -246,11 +246,24 @@ namespace ZZZStatsViewer
                     Console.WriteLine($"Obtained Time: {agent.ObtainmentTimestamp.ToLocalTime()}");
                     Console.WriteLine($"Weapon Effect State: {agent.WeaponEffectState}");
 
-                    Console.WriteLine("\nAGENT STATS:");
+                    foreach(var color in agent.Colors)
+                    {
+                        Console.WriteLine($"Color: {color.Accent} - {color.Mindscape}");
+                    }
+
+                    Console.WriteLine("\nAGENT STATS SIMPLE:");
                     var agentStats = agent.GetAllStats();
                     foreach (var statPair in agentStats)
                     {
                         Console.WriteLine($"{statPair.Key}: {statPair.Value}");
+                    }
+
+                    Console.WriteLine("\nAGENT STATS DETAILED:");
+                    var agentStatsDetailed = agent.GetAllStats();
+                    foreach (var statPair in agentStats)
+                    {
+                        Console.WriteLine($"{statPair.Key}: {statPair.Value.Final}");
+                        Console.WriteLine($"{statPair.Value.Base} + {statPair.Value.Added}");
                     }
 
                     if (agent.Weapon != null)


### PR DESCRIPTION
- Changed relic data fetching in `HSRAssets.cs` to use a dictionary for improved processing.
- Removed `HSRRelicData` class from `HSRRelicAssetInfo.cs`, indicating a new data structure.
- Updated `GetAllStats` method in `ZZZAgent.cs` to return detailed `FormattedStatValues`.
- Simplified stat representation in `ZZZDriveDisc.cs` by removing stat level from output.
- Incremented version number in `EnkaDotNet.csproj` from 1.3.3 to 1.3.4.
- Reformatted `StatPropertyType` enum in `HSREnums.cs` for clarity.
- Reordered enum values in `WEngineEffectState.cs` for consistency.
- Enhanced stat property mapping in `HSRStatPropertyUtils.cs` with new properties.
- Changed stats calculation method in `HSRStatsCalculator.cs` to use flooring instead of rounding.
- Updated `CalculateAllTotalStats` return type in `ZZZStatsHelpers.cs` for detailed breakdowns.
- Changed default language in `README.md` from Japanese to English.
- Added `StatSummary.cs` to encapsulate statistical data with implicit string conversion.
- Ensured consistency in statistical calculations and output clarity across various files.