### PR TITLE
Refactor EnkaDotNet for improved structure and handling

### DIFF
--- a/EnkaDotNet/DIExtensions/EnkaDotNetServiceCollectionExtensions.cs
+++ b/EnkaDotNet/DIExtensions/EnkaDotNetServiceCollectionExtensions.cs
@@ -5,9 +5,6 @@ using EnkaDotNet.Assets.HSR;
 using EnkaDotNet.Assets.ZZZ;
 using EnkaDotNet.Enums;
 using EnkaDotNet.Utils.Common;
-using EnkaDotNet.Utils.Genshin;
-using EnkaDotNet.Utils.HSR;
-using EnkaDotNet.Utils.ZZZ;
 using EnkaDotNet.Utils;
 using EnkaDotNet.Exceptions;
 using Microsoft.Extensions.Caching.Memory;
@@ -74,13 +71,6 @@ namespace EnkaDotNet.DIExtensions
                         var logger = sp.GetService<ILogger<GenshinAssets>>() ?? NullLogger<GenshinAssets>.Instance;
                         return await AssetsFactory.CreateGenshinAsync(opts.Language, httpClient, logger).ConfigureAwait(false);
                     });
-                    services.TryAddTransient<DataMapper>(sp =>
-                    {
-                        var assetsTask = sp.GetRequiredService<Task<IGenshinAssets>>();
-                        var assets = assetsTask.ConfigureAwait(false).GetAwaiter().GetResult(); 
-                        var opts = sp.GetRequiredService<IOptions<EnkaClientOptions>>();
-                        return new DataMapper(assets, opts);
-                    });
                     break;
                 case GameType.HSR:
                     services.TryAddSingleton<Task<IHSRAssets>>(async sp =>
@@ -91,20 +81,6 @@ namespace EnkaDotNet.DIExtensions
                         var logger = sp.GetService<ILogger<HSRAssets>>() ?? NullLogger<HSRAssets>.Instance;
                         return await AssetsFactory.CreateHSRAsync(opts.Language, httpClient, logger).ConfigureAwait(false);
                     });
-                    services.TryAddTransient<HSRDataMapper>(sp =>
-                    {
-                        var assetsTask = sp.GetRequiredService<Task<IHSRAssets>>();
-                        var assets = assetsTask.ConfigureAwait(false).GetAwaiter().GetResult();
-                        var opts = sp.GetRequiredService<IOptions<EnkaClientOptions>>();
-                        return new HSRDataMapper(assets, opts);
-                    });
-                    services.TryAddTransient<HSRStatCalculator>(sp =>
-                    {
-                        var assetsTask = sp.GetRequiredService<Task<IHSRAssets>>();
-                        var assets = assetsTask.ConfigureAwait(false).GetAwaiter().GetResult();
-                        var clientOptions = sp.GetRequiredService<IOptions<EnkaClientOptions>>().Value;
-                        return new HSRStatCalculator(assets, clientOptions);
-                    });
                     break;
                 case GameType.ZZZ:
                     services.TryAddSingleton<Task<IZZZAssets>>(async sp =>
@@ -114,19 +90,6 @@ namespace EnkaDotNet.DIExtensions
                         var httpClient = httpClientFactory.CreateClient(nameof(ZZZAssets));
                         var logger = sp.GetService<ILogger<ZZZAssets>>() ?? NullLogger<ZZZAssets>.Instance;
                         return await AssetsFactory.CreateZZZAsync(opts.Language, httpClient, logger).ConfigureAwait(false);
-                    });
-                    services.TryAddTransient<ZZZDataMapper>(sp =>
-                    {
-                        var assetsTask = sp.GetRequiredService<Task<IZZZAssets>>();
-                        var assets = assetsTask.ConfigureAwait(false).GetAwaiter().GetResult();
-                        var opts = sp.GetRequiredService<IOptions<EnkaClientOptions>>();
-                        return new ZZZDataMapper(assets, opts);
-                    });
-                    services.TryAddTransient<ZZZStatsCalculator>(sp =>
-                    {
-                        var assetsTask = sp.GetRequiredService<Task<IZZZAssets>>();
-                        var assets = assetsTask.ConfigureAwait(false).GetAwaiter().GetResult();
-                        return new ZZZStatsCalculator(assets);
                     });
                     break;
                 default:

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.4.1</Version>
+       <Version>1.4.2</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -58,5 +58,6 @@
    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
+   <PackageReference Include="Polly" Version="8.5.2" />
  </ItemGroup>
 </Project>

--- a/EnkaDotNet/Internal/GenshinServiceHandler.cs
+++ b/EnkaDotNet/Internal/GenshinServiceHandler.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EnkaDotNet.Assets.Genshin;
+using EnkaDotNet.Components.Genshin;
+using EnkaDotNet.Enums;
+using EnkaDotNet.Exceptions;
+using EnkaDotNet.Models.Genshin;
+using EnkaDotNet.Utils;
+using EnkaDotNet.Utils.Common;
+using EnkaDotNet.Utils.Genshin;
+using Microsoft.Extensions.Logging;
+
+namespace EnkaDotNet.Internal
+{
+    internal class GenshinServiceHandler
+    {
+        private readonly IGenshinAssets _assets;
+        private readonly DataMapper _dataMapper;
+        private readonly EnkaClientOptions _options;
+        private readonly IHttpHelper _httpHelper;
+        private readonly ILogger _logger;
+
+        public GenshinServiceHandler(IGenshinAssets assets, EnkaClientOptions options, IHttpHelper httpHelper, ILogger logger)
+        {
+            _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _httpHelper = httpHelper ?? throw new ArgumentNullException(nameof(httpHelper));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dataMapper = new DataMapper(assets, options);
+        }
+
+        public async Task<ApiResponse> GetRawUserResponseAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            if (uid <= 0) throw new ArgumentException("UID must be a positive integer.", nameof(uid));
+
+            string endpoint = string.Format(Constants.GetUserInfoEndpointFormat(GameType.Genshin), uid);
+            ApiResponse response = await _httpHelper.Get<ApiResponse>(endpoint, bypassCache, cancellationToken).ConfigureAwait(false);
+
+            if (response == null)
+            {
+                _logger.LogWarning("API for Genshin UID {Uid} returned a successful HTTP status but with empty or null-deserializing content.", uid);
+                throw new PlayerNotFoundException(uid, $"API for Genshin UID {uid} returned a successful HTTP status but with no parsable content or essential data structures. The profile may not exist or is not public.");
+            }
+
+            if (response.PlayerInfo == null)
+            {
+                throw new ProfilePrivateException(uid, $"Profile data retrieved for Genshin Impact UID {uid}, but essential player information (PlayerInfo block) is missing. The profile might be private, the UID invalid, or an unexpected API response structure was received.");
+            }
+            return response;
+        }
+
+        public async Task<PlayerInfo> GetPlayerInfoAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            var playerInfo = _dataMapper.MapPlayerInfo(rawResponse.PlayerInfo);
+            playerInfo.Uid = rawResponse.Uid;
+            playerInfo.TTL = rawResponse.Ttl.ToString();
+            return playerInfo;
+        }
+
+        public async Task<IReadOnlyList<Character>> GetCharactersAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            if (rawResponse.AvatarInfoList == null)
+            {
+                _logger.LogInformation("Genshin UID {Uid} has public profile info but no character showcase data (AvatarInfoList is null).", uid);
+                return Array.Empty<Character>();
+            }
+            return _dataMapper.MapCharacters(rawResponse.AvatarInfoList).AsReadOnly();
+        }
+
+        public async Task<(PlayerInfo PlayerInfo, IReadOnlyList<Character> Characters)> GetUserProfileAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            var playerInfo = _dataMapper.MapPlayerInfo(rawResponse.PlayerInfo);
+            playerInfo.Uid = rawResponse.Uid;
+            playerInfo.TTL = rawResponse.Ttl.ToString();
+
+            IReadOnlyList<Character> characters = Array.Empty<Character>();
+            if (rawResponse.AvatarInfoList != null)
+            {
+                characters = _dataMapper.MapCharacters(rawResponse.AvatarInfoList).AsReadOnly();
+            }
+            else
+            {
+                _logger.LogInformation("Genshin UID {Uid} has public profile info but no character showcase data (AvatarInfoList is null) for GetUserProfileAsync.", uid);
+            }
+            return (playerInfo, characters);
+        }
+    }
+}

--- a/EnkaDotNet/Internal/HSRServiceHandler.cs
+++ b/EnkaDotNet/Internal/HSRServiceHandler.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EnkaDotNet.Assets.HSR;
+using EnkaDotNet.Components.HSR;
+using EnkaDotNet.Enums;
+using EnkaDotNet.Exceptions;
+using EnkaDotNet.Models.HSR;
+using EnkaDotNet.Utils;
+using EnkaDotNet.Utils.Common;
+using EnkaDotNet.Utils.HSR;
+using Microsoft.Extensions.Logging;
+
+namespace EnkaDotNet.Internal
+{
+    internal class HSRServiceHandler
+    {
+        private readonly IHSRAssets _assets;
+        private readonly HSRDataMapper _dataMapper;
+        private readonly EnkaClientOptions _options;
+        private readonly IHttpHelper _httpHelper;
+        private readonly ILogger _logger;
+
+        public HSRServiceHandler(IHSRAssets assets, EnkaClientOptions options, IHttpHelper httpHelper, ILogger logger)
+        {
+            _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _httpHelper = httpHelper ?? throw new ArgumentNullException(nameof(httpHelper));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dataMapper = new HSRDataMapper(assets, options);
+        }
+
+        public async Task<HSRApiResponse> GetRawHSRUserResponseAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            if (uid <= 0) throw new ArgumentException("UID must be a positive integer.", nameof(uid));
+
+            string endpoint = string.Format(Constants.GetUserInfoEndpointFormat(GameType.HSR), uid);
+            HSRApiResponse response = await _httpHelper.Get<HSRApiResponse>(endpoint, bypassCache, cancellationToken).ConfigureAwait(false);
+
+            if (response == null)
+            {
+                _logger.LogWarning("API for HSR UID {Uid} returned a successful HTTP status but with empty or null-deserializing content.", uid);
+                throw new PlayerNotFoundException(uid, $"API for HSR UID {uid} returned a successful HTTP status but with no parsable content or essential data structures. The profile may not exist or is not public.");
+            }
+
+            if (response.DetailInfo == null)
+            {
+                throw new ProfilePrivateException(uid, $"Profile data retrieved for HSR UID {uid}, but essential detail information (DetailInfo block) is missing. The profile might be private, the UID invalid, or an unexpected API response structure was received.");
+            }
+            return response;
+        }
+
+        public async Task<HSRPlayerInfo> GetHSRPlayerInfoAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawHSRUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            return _dataMapper.MapPlayerInfo(rawResponse);
+        }
+
+        public async Task<IReadOnlyList<HSRCharacter>> GetHSRCharactersAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawHSRUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            if (rawResponse.DetailInfo?.AvatarDetailList == null)
+            {
+                _logger.LogInformation("HSR UID {Uid} has public profile info but no character showcase data (AvatarDetailList is null).", uid);
+                return Array.Empty<HSRCharacter>();
+            }
+            var characters = new List<HSRCharacter>();
+            foreach (var avatarDetail in rawResponse.DetailInfo.AvatarDetailList)
+            {
+                characters.Add(_dataMapper.MapCharacter(avatarDetail));
+            }
+            return characters.AsReadOnly();
+        }
+    }
+}

--- a/EnkaDotNet/Internal/ZZZServiceHandler.cs
+++ b/EnkaDotNet/Internal/ZZZServiceHandler.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EnkaDotNet.Assets.ZZZ;
+using EnkaDotNet.Components.ZZZ;
+using EnkaDotNet.Enums;
+using EnkaDotNet.Exceptions;
+using EnkaDotNet.Models.ZZZ;
+using EnkaDotNet.Utils;
+using EnkaDotNet.Utils.Common;
+using EnkaDotNet.Utils.ZZZ;
+using Microsoft.Extensions.Logging;
+
+namespace EnkaDotNet.Internal
+{
+    internal class ZZZServiceHandler
+    {
+        private readonly IZZZAssets _assets;
+        private readonly ZZZDataMapper _dataMapper;
+        private readonly EnkaClientOptions _options;
+        private readonly IHttpHelper _httpHelper;
+        private readonly ILogger _logger;
+
+        public ZZZServiceHandler(IZZZAssets assets, EnkaClientOptions options, IHttpHelper httpHelper, ILogger logger)
+        {
+            _assets = assets ?? throw new ArgumentNullException(nameof(assets));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _httpHelper = httpHelper ?? throw new ArgumentNullException(nameof(httpHelper));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dataMapper = new ZZZDataMapper(assets, options);
+        }
+
+        public async Task<ZZZApiResponse> GetRawZZZUserResponseAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            if (uid <= 0) throw new ArgumentException("UID must be a positive integer.", nameof(uid));
+
+            string endpoint = string.Format(Constants.GetUserInfoEndpointFormat(GameType.ZZZ), uid);
+            ZZZApiResponse response = await _httpHelper.Get<ZZZApiResponse>(endpoint, bypassCache, cancellationToken).ConfigureAwait(false);
+
+            if (response == null)
+            {
+                _logger.LogWarning("API for ZZZ UID {Uid} returned a successful HTTP status but with empty or null-deserializing content.", uid);
+                throw new PlayerNotFoundException(uid, $"API for ZZZ UID {uid} returned a successful HTTP status but with no parsable content or essential data structures. The profile may not exist or is not public.");
+            }
+
+            if (response.PlayerInfo == null)
+            {
+                throw new ProfilePrivateException(uid, $"Profile data retrieved for ZZZ UID {uid}, but essential player information (PlayerInfo block) is missing. The profile might be private, the UID invalid, or an unexpected API response structure was received.");
+            }
+            return response;
+        }
+
+        public async Task<ZZZPlayerInfo> GetZZZPlayerInfoAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawZZZUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            return _dataMapper.MapPlayerInfo(rawResponse);
+        }
+
+        public async Task<IReadOnlyList<ZZZAgent>> GetZZZAgentsAsync(int uid, bool bypassCache, CancellationToken cancellationToken)
+        {
+            var rawResponse = await GetRawZZZUserResponseAsync(uid, bypassCache, cancellationToken).ConfigureAwait(false);
+            if (rawResponse.PlayerInfo?.ShowcaseDetail?.AvatarList == null)
+            {
+                _logger.LogInformation("ZZZ UID {Uid} has public profile info but no agent showcase data (AvatarList is null).", uid);
+                return Array.Empty<ZZZAgent>();
+            }
+            var agents = new List<ZZZAgent>();
+            foreach (var avatarModel in rawResponse.PlayerInfo.ShowcaseDetail.AvatarList)
+            {
+                if (avatarModel != null)
+                {
+                    var agent = _dataMapper.MapAgent(avatarModel);
+                    if (agent != null) agents.Add(agent);
+                }
+            }
+            return agents.AsReadOnly();
+        }
+    }
+}

--- a/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
+++ b/EnkaDotNet/Utils/ZZZ/ZZZStatsCalculator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using EnkaDotNet.Assets.ZZZ;
 using EnkaDotNet.Assets.ZZZ.Models;
 using EnkaDotNet.Components.ZZZ;
@@ -10,7 +11,8 @@ namespace EnkaDotNet.Utils.ZZZ
 {
     public class ZZZStatsCalculator
     {
-        private readonly IZZZAssets _assets;
+        private readonly Task<IZZZAssets> _assetsTask;
+        private IZZZAssets _assets;
         private Dictionary<string, object> _calculationCache = new Dictionary<string, object>();
 
         public ZZZStatsCalculator(IZZZAssets assets)

--- a/EnkaDotNet/packages.lock.json
+++ b/EnkaDotNet/packages.lock.json
@@ -110,12 +110,29 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "Polly": {
+        "type": "Direct",
+        "requested": "[8.5.2, )",
+        "resolved": "8.5.2",
+        "contentHash": "vbXsGgkG86nG+TOwY+SmtrGrRHmHH0DQaxtILx//d3Dz/ocJ8izSNYzdvU2gEtWa/LDD8zJLvD3HdjEkdlvkhg==",
+        "dependencies": {
+          "Polly.Core": "8.5.2"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "9VGI5kxIvrNG2mqLQZnUR6y/3fcnygD8eNpHR+CqfbnIXvea6nehnYknDKQTxZVPMpzpNca+7DxLBmpdB3q0Bw==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -192,6 +209,17 @@
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.5.2",
+        "contentHash": "1MJKdxv4zwDmiWvYvVN24DsrWUfgQ4F83voH8bhbtLMdPuGy8CfTUzsgQhvyrl1a7hrM6f/ydwLVdVUI0xooUw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.TimeProvider": "8.0.0",
+          "System.ComponentModel.Annotations": "4.5.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "System.Buffers": {
         "type": "Transitive",


### PR DESCRIPTION
- Simplified constructors for DataMapper classes by removing IOptions<EnkaClientOptions>.
- Introduced new service handler classes for Genshin, HSR, and ZZZ to enhance separation of concerns.
- Enhanced HttpHelper with a retry policy using Polly for better error handling.
- Incremented project version from 1.4.1 to 1.4.2.
- Removed unused namespaces and improved code readability.
- Overall architecture improvements for easier future extensions and modifications.