### PR TITLE
Enhance retry and caching mechanisms in EnkaDotNet

### DIFF
--- a/EnkaDotNet/EnkaClientOptions.cs
+++ b/EnkaDotNet/EnkaClientOptions.cs
@@ -2,28 +2,98 @@
 using EnkaDotNet.Utils;
 using System.Collections.Generic;
 using System.Net;
+using System;
 
 namespace EnkaDotNet
 {
     public class EnkaClientOptions
     {
+        private int _maxRetries = 1;
+        private int _retryDelayMs = 1000;
+        private int _maxRetryDelayMs = 30000;
+        private int _timeoutSeconds = 30;
+        private int _cacheDurationMinutes = 5;
+
+
         public string UserAgent { get; set; } = Constants.DefaultUserAgent;
         public string BaseUrl { get; set; }
-        public int TimeoutSeconds { get; set; } = 30;
-        public bool EnableCaching { get; set; } = true;
-        public int CacheDurationMinutes { get; set; } = 5;
 
-        public int MaxRetries { get; set; } = 0;
-        public int RetryDelayMs { get; set; } = 1000;
+        public int TimeoutSeconds
+        {
+            get => _timeoutSeconds;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(TimeoutSeconds), "TimeoutSeconds must be greater than 0.");
+                }
+                _timeoutSeconds = value;
+            }
+        }
+
+        public bool EnableCaching { get; set; } = true;
+
+        public int CacheDurationMinutes
+        {
+            get => _cacheDurationMinutes;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(CacheDurationMinutes), "CacheDurationMinutes cannot be negative.");
+                }
+                _cacheDurationMinutes = value;
+            }
+        }
+
+        public int MaxRetries
+        {
+            get => _maxRetries;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(MaxRetries), "MaxRetries must be at least 1.");
+                }
+                _maxRetries = value;
+            }
+        }
+
+        public int RetryDelayMs
+        {
+            get => _retryDelayMs;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(RetryDelayMs), "RetryDelayMs cannot be negative.");
+                }
+                _retryDelayMs = value;
+            }
+        }
+
         public bool UseExponentialBackoff { get; set; } = true;
-        public int MaxRetryDelayMs { get; set; } = 30000;
+
+        public int MaxRetryDelayMs
+        {
+            get => _maxRetryDelayMs;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(MaxRetryDelayMs), "MaxRetryDelayMs cannot be negative.");
+                }
+                _maxRetryDelayMs = value;
+            }
+        }
+
         public List<HttpStatusCode> RetryOnStatusCodes { get; set; } = new List<HttpStatusCode>
         {
-            HttpStatusCode.InternalServerError, // 500
-            HttpStatusCode.BadGateway,          // 502
-            HttpStatusCode.ServiceUnavailable,  // 503
-            HttpStatusCode.GatewayTimeout,      // 504
-            (HttpStatusCode)429                 // TooManyRequests
+            HttpStatusCode.InternalServerError,
+            HttpStatusCode.BadGateway,
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.GatewayTimeout,
+            (HttpStatusCode)429
         };
 
         public bool EnableVerboseLogging { get; set; } = false;

--- a/EnkaDotNet/EnkaClientOptions.cs
+++ b/EnkaDotNet/EnkaClientOptions.cs
@@ -96,7 +96,6 @@ namespace EnkaDotNet
             (HttpStatusCode)429
         };
 
-        public bool EnableVerboseLogging { get; set; } = false;
         public string Language { get; set; } = "en";
         public GameType GameType { get; set; } = GameType.Genshin;
         public bool Raw { get; set; } = false;

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.4.2</Version>
+       <Version>1.4.3</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -52,12 +52,9 @@
  <ItemGroup>
    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-   <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-   <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
-   <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
-   <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
    <PackageReference Include="Polly" Version="8.5.2" />
+   <PackageReference Include="System.Text.Json" Version="9.0.4" />
  </ItemGroup>
 </Project>

--- a/EnkaDotNet/Utils/Common/CacheEntry.cs
+++ b/EnkaDotNet/Utils/Common/CacheEntry.cs
@@ -5,7 +5,6 @@ namespace EnkaDotNet.Utils.Common
     public class CacheEntry
     {
         public string JsonResponse { get; set; } = string.Empty;
-        public string ETag { get; set; }
         public DateTimeOffset Expiration { get; set; }
         public bool IsExpired => DateTimeOffset.UtcNow > Expiration;
     }

--- a/EnkaDotNet/packages.lock.json
+++ b/EnkaDotNet/packages.lock.json
@@ -26,16 +26,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "UI0TQPVkS78bFdjkTodmkH0Fe8lXv9LnhGFKgKrsgUJ5a5FVdFRcgjIkBVLbGgdRhxWirxH/8IXUtEyYJx6GQg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
         "requested": "[9.0.4, )",
@@ -47,47 +37,6 @@
           "Microsoft.Extensions.Logging": "9.0.4",
           "Microsoft.Extensions.Logging.Abstractions": "9.0.4",
           "Microsoft.Extensions.Options": "9.0.4"
-        }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "xW6QPYsqhbuWBO9/1oA43g/XPKbohJx+7G8FLQgQXIriYvY7s+gxr2wjQJfRoPO900dvvv2vVH7wZovG+M1m6w==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
-          "Microsoft.Extensions.DependencyInjection": "9.0.4",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Options": "9.0.4",
-          "System.Diagnostics.DiagnosticSource": "9.0.4"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "0MXlimU4Dud6t+iNi5NEz3dO2w1HXdhoOLaYFuLPCjAsvlPQGwOT6V2KZRMLEhCAm/stSZt1AUv0XmDdkjvtbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
-          "System.Buffers": "4.5.1",
-          "System.Diagnostics.DiagnosticSource": "9.0.4",
-          "System.Memory": "4.5.5"
-        }
-      },
-      "Microsoft.Extensions.Logging.Console": {
-        "type": "Direct",
-        "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "cI0lQe0js65INCTCtAgnlVJWKgzgoRHVAW1B1zwCbmcliO4IZoTf92f1SYbLeLk7FzMJ/GlCvjLvJegJ6kltmQ==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Logging": "9.0.4",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Logging.Configuration": "9.0.4",
-          "Microsoft.Extensions.Options": "9.0.4",
-          "System.Buffers": "4.5.1",
-          "System.Text.Json": "9.0.4"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -119,6 +68,21 @@
           "Polly.Core": "8.5.2"
         }
       },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "pYtmpcO6R3Ef1XilZEHgXP2xBPVORbYEzRP7dl0IAAbN8Dm+kfwio8aCKle97rAWXOExr292MuxWYurIuwN62g==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.4",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "9.0.4",
@@ -144,15 +108,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "KIVBrMbItnCJDd1RF4KEaE8jZwDJcDUJW5zXpbwQ05HNYTK1GveHxHK0B3SjgDJuR48GRACXAO+BLhL8h34S7g==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Primitives": "9.0.4"
-        }
-      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "9.0.4",
@@ -161,39 +116,36 @@
           "Microsoft.Extensions.Primitives": "9.0.4"
         }
       },
-      "Microsoft.Extensions.Configuration.Binder": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "9.0.4",
-        "contentHash": "cdrjcl9RIcwt3ECbnpP0Gt1+pkjdW90mq5yFYy8D9qRj2NqFFcv3yDp141iEamsd9E218sGxK8WHaIOcrqgDJg==",
+        "contentHash": "UI0TQPVkS78bFdjkTodmkH0Fe8lXv9LnhGFKgKrsgUJ5a5FVdFRcgjIkBVLbGgdRhxWirxH/8IXUtEyYJx6GQg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.4"
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Extensions.Logging.Configuration": {
+      "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "9.0.4",
-        "contentHash": "/kF+rSnoo3/nIwGzWsR4RgBnoTOdZ3lzz2qFRyp/GgaNid4j6hOAQrs/O+QHXhlcAdZxjg37MvtIE+pAvIgi9g==",
+        "contentHash": "xW6QPYsqhbuWBO9/1oA43g/XPKbohJx+7G8FLQgQXIriYvY7s+gxr2wjQJfRoPO900dvvv2vVH7wZovG+M1m6w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "9.0.4",
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Configuration.Binder": "9.0.4",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Logging": "9.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
+          "Microsoft.Extensions.DependencyInjection": "9.0.4",
           "Microsoft.Extensions.Logging.Abstractions": "9.0.4",
           "Microsoft.Extensions.Options": "9.0.4",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.4"
+          "System.Diagnostics.DiagnosticSource": "9.0.4"
         }
       },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+      "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
         "resolved": "9.0.4",
-        "contentHash": "aridVhAT3Ep+vsirR1pzjaOw0Jwiob6dc73VFQn2XmDfBA2X98M8YKO1GarvsXRX7gX1Aj+hj2ijMzrMHDOm0A==",
+        "contentHash": "0MXlimU4Dud6t+iNi5NEz3dO2w1HXdhoOLaYFuLPCjAsvlPQGwOT6V2KZRMLEhCAm/stSZt1AUv0XmDdkjvtbw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Configuration.Binder": "9.0.4",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
-          "Microsoft.Extensions.Options": "9.0.4",
-          "Microsoft.Extensions.Primitives": "9.0.4"
+          "System.Buffers": "4.5.1",
+          "System.Diagnostics.DiagnosticSource": "9.0.4",
+          "System.Memory": "4.5.5"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -278,20 +230,6 @@
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "pYtmpcO6R3Ef1XilZEHgXP2xBPVORbYEzRP7dl0IAAbN8Dm+kfwio8aCKle97rAWXOExr292MuxWYurIuwN62g==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "9.0.4",
-          "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "9.0.4",
-          "System.Memory": "4.5.5",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "9.0.4",
-          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "System.Threading.Tasks.Extensions": {


### PR DESCRIPTION
- Updated `EnkaClientOptions.cs` to add properties for managing retries and caching, including validation logic for `TimeoutSeconds` and `CacheDurationMinutes`.
- Changed project version in `EnkaDotNet.csproj` from `1.4.2` to `1.4.3`, removed unnecessary logging package references, and added `System.Text.Json`.
- Removed `ETag` property from `CacheEntry.cs` to simplify the class.
- Refactored retry logic in `HttpHelper.cs` to use a `ResiliencePipeline` and `RetryStrategyOptions`, improving error handling and caching.
- Updated `packages.lock.json` to reflect changes in package dependencies.