### PR TITLE
Bump version to 1.4.7 and configure HTTP client timeout

### DIFF
--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.4.6</Version>
+       <Version>1.4.7</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/EnkaDotNet/Utils/Common/HttpHelper.cs
+++ b/EnkaDotNet/Utils/Common/HttpHelper.cs
@@ -40,6 +40,7 @@ namespace EnkaDotNet.Utils.Common
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? NullLogger<HttpHelper>.Instance;
             _trackedCacheKeys = new ConcurrentDictionary<string, bool>();
+            _httpClient.Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds);
 
             var retryOptions = new RetryStrategyOptions<HttpResponseMessage>
             {


### PR DESCRIPTION
Updated the version number in `EnkaDotNet.csproj` from 1.4.6 to 1.4.7. Added configuration to set the HTTP client's timeout based on the `TimeoutSeconds` option in `HttpHelper.cs`, improving HTTP client settings.