### PR TITLE
Update ZZZ session 2 patch

### DIFF
--- a/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
+++ b/EnkaDotNet/Assets/ZZZ/ZZZAssets.cs
@@ -427,10 +427,12 @@ namespace EnkaDotNet.Assets.ZZZ
             switch (elementName?.ToUpperInvariant())
             {
                 case "FIRE": return ElementType.Fire;
-                case "ICE": case "FIREFROST": return ElementType.Ice;
+                case "ICE": return ElementType.Ice;
+                case "FIREFROST": return ElementType.FireFrost;
                 case "ELEC": return ElementType.Electric;
                 case "ETHER": return ElementType.Ether;
                 case "PHYSICS": return ElementType.Physical;
+                case "AURICETHER": return ElementType.AuricEther;
                 default: return ElementType.Unknown;
             }
         }
@@ -438,6 +440,7 @@ namespace EnkaDotNet.Assets.ZZZ
         {
             switch (professionName?.ToUpperInvariant())
             {
+                case "RUPTURE": return ProfessionType.Rupture;
                 case "ATTACK": return ProfessionType.Attack;
                 case "STUN": return ProfessionType.Stun;
                 case "ANOMALY": return ProfessionType.Anomaly;

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
        <RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
        <PackageLicenseFile>LICENSE</PackageLicenseFile>
        <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-       <Version>1.4.7</Version>
+       <Version>1.4.8</Version>
        <ApplicationIcon>image.ico</ApplicationIcon>
        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
        <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/EnkaDotNet/Enums/GameType.cs
+++ b/EnkaDotNet/Enums/GameType.cs
@@ -1,12 +1,4 @@
 ﻿using System.ComponentModel;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace EnkaDotNet.Enums
 {
     public enum GameType

--- a/EnkaDotNet/Enums/Genshin/ArtifactSlot.cs
+++ b/EnkaDotNet/Enums/Genshin/ArtifactSlot.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.Genshin
+﻿namespace EnkaDotNet.Enums.Genshin
 {
     public enum ArtifactSlot
     {

--- a/EnkaDotNet/Enums/Genshin/ElementType.cs
+++ b/EnkaDotNet/Enums/Genshin/ElementType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.Genshin
+﻿namespace EnkaDotNet.Enums.Genshin
 {
     public enum ElementType
     {

--- a/EnkaDotNet/Enums/Genshin/ItemType.cs
+++ b/EnkaDotNet/Enums/Genshin/ItemType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.Genshin
+﻿namespace EnkaDotNet.Enums.Genshin
 {
     public enum ItemType
     {

--- a/EnkaDotNet/Enums/Genshin/StatType.cs
+++ b/EnkaDotNet/Enums/Genshin/StatType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.Genshin
+﻿namespace EnkaDotNet.Enums.Genshin
 {
     public enum StatType
     {

--- a/EnkaDotNet/Enums/Genshin/WeaponType.cs
+++ b/EnkaDotNet/Enums/Genshin/WeaponType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.Genshin
+﻿namespace EnkaDotNet.Enums.Genshin
 {
     public enum WeaponType
     {

--- a/EnkaDotNet/Enums/HSR/HSREnums.cs
+++ b/EnkaDotNet/Enums/HSR/HSREnums.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.HSR
+﻿namespace EnkaDotNet.Enums.HSR
 {
     public enum ElementType
     {

--- a/EnkaDotNet/Enums/ZZZ/DriveDiscSlot.cs
+++ b/EnkaDotNet/Enums/ZZZ/DriveDiscSlot.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum DriveDiscSlot
     {

--- a/EnkaDotNet/Enums/ZZZ/ElementType.cs
+++ b/EnkaDotNet/Enums/ZZZ/ElementType.cs
@@ -14,7 +14,9 @@ namespace EnkaDotNet.Enums.ZZZ
         Physical,
         Fire,
         Ice,
+        FireFrost,
         Electric,
-        Ether
+        Ether,
+        AuricEther
     }
 }

--- a/EnkaDotNet/Enums/ZZZ/MedalType.cs
+++ b/EnkaDotNet/Enums/ZZZ/MedalType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum MedalType
     {

--- a/EnkaDotNet/Enums/ZZZ/ProfessionType.cs
+++ b/EnkaDotNet/Enums/ZZZ/ProfessionType.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum ProfessionType
     {
-        Unknown = 0,
+        Unknown,
         Attack,
         Stun,
         Anomaly,
         Defense,
-        Support
+        Support,
+        Rupture
     }
 }

--- a/EnkaDotNet/Enums/ZZZ/Rarity.cs
+++ b/EnkaDotNet/Enums/ZZZ/Rarity.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum Rarity
     {

--- a/EnkaDotNet/Enums/ZZZ/SkillType.cs
+++ b/EnkaDotNet/Enums/ZZZ/SkillType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum SkillType
     {

--- a/EnkaDotNet/Enums/ZZZ/StatSummary.cs
+++ b/EnkaDotNet/Enums/ZZZ/StatSummary.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public class StatSummary
     {

--- a/EnkaDotNet/Enums/ZZZ/StatType.cs
+++ b/EnkaDotNet/Enums/ZZZ/StatType.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum StatType
     {
@@ -65,6 +57,11 @@ namespace EnkaDotNet.Enums.ZZZ
         ElectricDMGBonusBase = 31801, // Electric DMG Bonus [Base]
         ElectricDMGBonusFlat = 31803, // Electric DMG Bonus [Flat]
         EtherDMGBonusBase = 31901,    // Ether DMG Bonus [Base]
-        EtherDMGBonusFlat = 31903     // Ether DMG Bonus [Flat]
+        EtherDMGBonusFlat = 31903,     // Ether DMG Bonus [Flat]
+
+        // Rupture Agent Specific Stats
+        AutomaticAdrenalineAccumulationBase = 32001, // Automatic Adrenaline Accumulation [Base]
+        AutomaticAdrenalineAccumulationPercent = 32002, // Automatic Adrenaline Accumulation%
+        AutomaticAdrenalineAccumulationFlat = 32003, // Automatic Adrenaline Accumulation [Flat]
     }
 }

--- a/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
+++ b/EnkaDotNet/Enums/ZZZ/WEngineEffectState.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace EnkaDotNet.Enums.ZZZ
+﻿namespace EnkaDotNet.Enums.ZZZ
 {
     public enum WEngineEffectState
     {

--- a/EnkaDotNet/Utils/Constants.cs
+++ b/EnkaDotNet/Utils/Constants.cs
@@ -72,15 +72,15 @@ namespace EnkaDotNet.Utils
         /// </summary>
         public static readonly IReadOnlyDictionary<string, string> HSRAssetFileUrls = new Dictionary<string, string>()
         {
-            { "text_map.json", "https://raw.githubusercontent.com/seriaati/enka-py-assets/main/data/hsr/hsr.json" },
-            { "characters.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_characters.json" },
-            { "lightcones.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_weps.json" },
-            { "relics.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_relics.json" },
-            { "avatars.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_avatars.json" },
-            { "skills.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_skills.json" },
-            { "ranks.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_ranks.json" },
+            { "text_map.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/hsr.json" },
+            { "characters.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_characters.json" },
+            { "lightcones.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_weps.json" },
+            { "relics.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_relics.json" },
+            { "avatars.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_avatars.json" },
+            { "skills.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_skills.json" },
+            { "ranks.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_ranks.json" },
             { "skill_tree.json", "https://raw.githubusercontent.com/seriaati/enka-py-assets/main/data/hsr/skill_tree.json" },
-            { "meta.json", "https://raw.githubusercontent.com/EnkaNetwork/API-docs/master/store/hsr/honker_meta.json" }
+            { "meta.json", "https://raw.githubusercontent.com/pizza-studio/EnkaDBGenerator/refs/heads/main/Sources/EnkaDBFiles/Resources/Specimen/HSR/honker_meta.json" }
         };
 
         /// <summary>


### PR DESCRIPTION
- Updated `MapElementNameToEnum` to correctly map "FIREFROST" to `ElementType.FireFrost` and added "AURICETHER" to return `ElementType.AuricEther`.
- Incremented project version from `1.4.7` to `1.4.8`.
- Cleaned up `using` directives in multiple files within the `EnkaDotNet.Enums.Genshin` namespace.
- Modified `ElementType` enum to include `FireFrost` and `AuricEther`.
- Updated `ProfessionType` enum to add `Rupture` and simplified its definition.
- Changed asset file URLs in `Constants.cs` to point to a new repository.
- Enhanced `ZZZStatsHelpers.cs` methods to support a new `agent` parameter in `CalculateFinalValues`, introducing new stat categories like "Sheer Force" and "Automatic Adrenaline Accumulation".
- Expanded handling of various stat types for improved functionality and maintainability.