### PR TITLE
Update formatting logic and version number

### DIFF
--- a/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
+++ b/EnkaDotNet/Components/ZZZ/ZZZWEngine.cs
@@ -53,7 +53,7 @@ namespace EnkaDotNet.Components.ZZZ
                 }
                 else
                 {
-                    if (SecondaryStat.Type == StatType.EnergyRegenPercent) value = (SecondaryStat.Value / 100.0).ToString("F1", CultureInfo.InvariantCulture) + "%";
+                    if (SecondaryStat.Type == StatType.EnergyRegenPercent) value = (SecondaryStat.Value).ToString("F1", CultureInfo.InvariantCulture) + "%";
                     else if (SecondaryStat.IsPercentage) value = SecondaryStat.Value.ToString("F1", CultureInfo.InvariantCulture) + "%";
                     else value = Math.Floor(SecondaryStat.Value).ToString(CultureInfo.InvariantCulture);
                 }

--- a/EnkaDotNet/EnkaDotNet.csproj
+++ b/EnkaDotNet/EnkaDotNet.csproj
@@ -16,7 +16,7 @@
 		<RepositoryUrl>https://github.com/aliafuji/EnkaDotnet</RepositoryUrl>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.5.0.2</Version>
+		<Version>1.5.0.3</Version>
 		<ApplicationIcon>image.ico</ApplicationIcon>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>


### PR DESCRIPTION
Modified the `SecondaryStat.Value` formatting in `ZZZWEngine.cs` to remove division by 100.0 for `EnergyRegenPercent` and ensure consistent percentage output. Updated the package version in `EnkaDotNet.csproj` from `1.5.0.2` to `1.5.0.3`.